### PR TITLE
Add environment (reader-monad behaviour)

### DIFF
--- a/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
+++ b/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="LanguageExt.Core" Version="3.3.47" />
-    <PackageReference Include="Selenium.Chrome.WebDriver" Version="81.0.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="84.0.4147.3001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Isotope80.Samples.Console/Meddbase.cs
+++ b/samples/Isotope80.Samples.Console/Meddbase.cs
@@ -2,37 +2,38 @@
 using OpenQA.Selenium;
 using static LanguageExt.Prelude;
 using static Isotope80.Isotope;
+using System;
 
 namespace Isotope80.Samples.Console
 {
     public static class Meddbase
     {
-        public static Isotope<Unit> GoToDesktopSite =>
+        public static Isotope<Unit, Unit> GoToDesktopSite =>
             context("Go to Desktop Site",
-                    from _1 in log("Update Window Size")
-                    from _2 in setWindowSize(1280,960)
-                    from _3 in nav("https://www.meddbase.com")
+                    from _1 in log<Unit>("Update Window Size")
+                    from _2 in setWindowSize<Unit>(1280,960)
+                    from _3 in nav<Unit>("https://www.meddbase.com")
                     select unit);
 
-        public static Isotope<Unit> WaitThenClick(By selector) =>
-            from el in waitUntilClickable(selector)
-            from _2 in click(el)
+        public static Isotope<Unit, Unit> WaitThenClick(By selector) =>
+            from el in waitUntilClickable<Unit>(selector)
+            from _2 in click<Unit>(el)
             select unit;
 
-        public static Isotope<Unit> ClickMoreMenu =>
+        public static Isotope<Unit, Unit> ClickMoreMenu =>
             context("Click More menu",
                     WaitThenClick(css("#menu-item-39 > a")));
 
-        public static Isotope<Unit> ClickCareersMenu =>
+        public static Isotope<Unit, Unit> ClickCareersMenu =>
             context("Click Careers menu",
                     WaitThenClick(css("#menu-item-29 > a")));
 
-        public static Isotope<Seq<string>> SelectVacancyTitles =>
-            from links in findElements(xPath(@"//section[@class=""careers""]//div[h2[text() = ""Current Vacancies""]]/div[@class=""item""]/a"))
+        public static Isotope<Unit, Seq<string>> SelectVacancyTitles =>
+            from links in findElements<Unit>(xPath(@"//section[@class=""careers""]//div[h2[text() = ""Current Vacancies""]]/div[@class=""item""]/a"))
             let title = links.Map(x => x.Text)
             select title;
 
-        public static Isotope<Seq<string>> GoToPageAndOpenCareers =>
+        public static Isotope<Unit, Seq<string>> GoToPageAndOpenCareers =>
             from _1 in GoToDesktopSite
             from _2 in ClickMoreMenu
             from _3 in ClickCareersMenu

--- a/samples/Isotope80.Samples.Console/Program.cs
+++ b/samples/Isotope80.Samples.Console/Program.cs
@@ -1,6 +1,7 @@
 ﻿using OpenQA.Selenium.Chrome;
 using System;
 using static System.Console;
+using static LanguageExt.Prelude;
 
 namespace Isotope80.Samples.Console
 {
@@ -12,6 +13,7 @@ namespace Isotope80.Samples.Console
                 (x, y) => WriteLine(new string('\t', y) + x);
 
             (var state, var value) = Meddbase.GoToPageAndOpenCareers.Run(
+                unit,
                 new ChromeDriver(), 
                     IsotopeSettings.Create(
                         loggingAction: consoleLogger));

--- a/samples/Isotope80.Samples.UnitTests/Careers.cs
+++ b/samples/Isotope80.Samples.UnitTests/Careers.cs
@@ -1,13 +1,12 @@
-﻿using Isotope80;
-using System;
-using Xunit;
-using static Isotope80.Isotope;
-using static Isotope80.Assertions;
-using LanguageExt;
-using static LanguageExt.Prelude;
+﻿using LanguageExt;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
+using System;
+using Xunit;
 using Xunit.Abstractions;
+using static Isotope80.Assertions;
+using static Isotope80.Isotope;
+using static LanguageExt.Prelude;
 
 namespace Isotope80.Samples.UnitTests
 {
@@ -52,17 +51,17 @@ namespace Isotope80.Samples.UnitTests
             select unit;
 
         [Fact]
-        public void CareersMenuItemLoadsCareersPage() 
+        public void CareersMenuItemLoadsCareersPage()
         {
-            var expected = "https://www.meddbase.com/careers/";
+            var expected = "https://www.meddbase.com/jobs-at-meddbase/";
 
-            var iso = from _1  in GoToPageAndOpenCareers
+            var iso = from _1 in GoToPageAndOpenCareers
                       from url in url<Unit>()
-                      from _2  in assert<Unit>(url == expected, $"Expected URL to be {expected} but it was {url}")
+                      from _2 in assert<Unit>(url == expected, $"Expected URL to be {expected} but it was {url}")
                       select unit;
-           
-            Action<string, Log> xunitOutput = 
-                (x,y) => output.WriteLine(y.ToString());
+
+            Action<string, Log> xunitOutput =
+                (x, y) => output.WriteLine(y.ToString());
 
             (var state, var value) = iso.RunAndThrowOnError(
                 unit,

--- a/samples/Isotope80.Samples.UnitTests/Careers.cs
+++ b/samples/Isotope80.Samples.UnitTests/Careers.cs
@@ -20,32 +20,32 @@ namespace Isotope80.Samples.UnitTests
             this.output = output;
         }
 
-        public static Isotope<Unit> GoToDesktopSite =>
+        public static Isotope<Unit, Unit> GoToDesktopSite =>
             context("Go to Desktop Site",
-                    from _1 in log("Update Window Size")
-                    from _2 in setWindowSize(1280, 960)
-                    from _3 in nav("https://www.meddbase.com")
+                    from _1 in log<Unit>("Update Window Size")
+                    from _2 in setWindowSize<Unit>(1280, 960)
+                    from _3 in nav<Unit>("https://www.meddbase.com")
                     select unit);
 
-        public static Isotope<Unit> WaitThenClick(By selector) =>
-            from el in waitUntilClickable(selector)
-            from _2 in click(selector)
+        public static Isotope<Unit, Unit> WaitThenClick(By selector) =>
+            from el in waitUntilClickable<Unit>(selector)
+            from _2 in click<Unit>(selector)
             select unit;
 
-        public static Isotope<Unit> ClickMoreMenu =>
+        public static Isotope<Unit, Unit> ClickMoreMenu =>
             context("Click More menu",
                     WaitThenClick(By.CssSelector("#menu-item-39 > a")));
 
-        public static Isotope<Unit> ClickCareersMenu =>
+        public static Isotope<Unit, Unit> ClickCareersMenu =>
             context("Click Careers menu",
                     WaitThenClick(By.CssSelector("#menu-item-29 > a")));
 
-        public static Isotope<Seq<string>> SelectVacancyTitles =>
-            from links in findElements(By.XPath(@"//section[@class=""careers""]//div[h2[text() = ""Current Vacancies""]]/div[@class=""item""]/a"))
+        public static Isotope<Unit, Seq<string>> SelectVacancyTitles =>
+            from links in findElements<Unit>(By.XPath(@"//section[@class=""careers""]//div[h2[text() = ""Current Vacancies""]]/div[@class=""item""]/a"))
             let title = links.Map(x => x.Text)
             select title;
 
-        public static Isotope<Unit> GoToPageAndOpenCareers =>
+        public static Isotope<Unit, Unit> GoToPageAndOpenCareers =>
             from _1 in GoToDesktopSite
             from _2 in ClickMoreMenu
             from _3 in ClickCareersMenu
@@ -57,14 +57,17 @@ namespace Isotope80.Samples.UnitTests
             var expected = "https://www.meddbase.com/careers/";
 
             var iso = from _1  in GoToPageAndOpenCareers
-                      from url in url
-                      from _2  in assert(url == expected, $"Expected URL to be {expected} but it was {url}")
+                      from url in url<Unit>()
+                      from _2  in assert<Unit>(url == expected, $"Expected URL to be {expected} but it was {url}")
                       select unit;
            
             Action<string, Log> xunitOutput = 
                 (x,y) => output.WriteLine(y.ToString());
 
-            (var state, var value) = iso.RunAndThrowOnError(new ChromeDriver(), settings: IsotopeSettings.Create(failureAction: xunitOutput));
+            (var state, var value) = iso.RunAndThrowOnError(
+                unit,
+                new ChromeDriver(),
+                settings: IsotopeSettings.Create(failureAction: xunitOutput));
         }
     }
 }

--- a/samples/Isotope80.Samples.UnitTests/Environment.cs
+++ b/samples/Isotope80.Samples.UnitTests/Environment.cs
@@ -1,12 +1,6 @@
-﻿using LanguageExt;
-using OpenQA.Selenium;
-using OpenQA.Selenium.Chrome;
-using System;
+﻿using System;
 using Xunit;
-using Xunit.Abstractions;
 using static Isotope80.Assertions;
-using static Isotope80.Isotope;
-using static LanguageExt.Prelude;
 
 namespace Isotope80.Samples.UnitTests
 {

--- a/samples/Isotope80.Samples.UnitTests/Environment.cs
+++ b/samples/Isotope80.Samples.UnitTests/Environment.cs
@@ -1,0 +1,51 @@
+﻿using LanguageExt;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+using static Isotope80.Assertions;
+using static Isotope80.Isotope;
+using static LanguageExt.Prelude;
+
+namespace Isotope80.Samples.UnitTests
+{
+    public class Environment
+    {
+        [Fact]
+        public void Environment_CanBeAskedFor()
+        {
+            var computation =
+                from env in Isotope.ask<ITestEnv>()
+                let result = env.Add(2, 3)
+                select result;
+
+            var (state, value) = computation.Run(new TestEnv());
+
+            assert<ITestEnv>(value == 5, $"Expected 5 but was {value}");
+        }
+
+        [Fact]
+        public void EnvironmentMember_CanBeAskedFor()
+        {
+            var computation =
+                from add in Isotope.asks<ITestEnv, Func<int, int, int>>(e => e.Add)
+                let result = add(2, 3)
+                select result;
+
+            var (state, value) = computation.Run(new TestEnv());
+
+            assert<ITestEnv>(value == 5, $"Expected 5 but was {value}");
+        }
+    }
+
+    public interface ITestEnv
+    {
+        int Add(int a, int b);
+    }
+
+    public class TestEnv : ITestEnv
+    {
+        public int Add(int a, int b) => a + b;
+    }
+}

--- a/samples/Isotope80.Samples.UnitTests/Isotope80.Samples.UnitTests.csproj
+++ b/samples/Isotope80.Samples.UnitTests/Isotope80.Samples.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Selenium.Chrome.WebDriver" Version="79.0.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="84.0.4147.3001" />
     <PackageReference Include="XUnit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Isotope80/Assertions.cs
+++ b/src/Isotope80/Assertions.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using LanguageExt;
+﻿using LanguageExt;
 using OpenQA.Selenium;
+using System;
 using static Isotope80.Isotope;
 using static LanguageExt.Prelude;
 
@@ -8,37 +8,37 @@ namespace Isotope80
 {
     public static class Assertions
     {
-        public static Isotope<Unit> assert(Isotope<bool> fact, string label) =>
+        public static Isotope<Env, Unit> assert<Env>(Isotope<Env, bool> fact, string label) =>
             from f in fact
-            from _ in assert(f, label)
-            select unit;
-        
-        public static Isotope<Unit> assert(Func<bool> fact, string label) =>
-            assert(fact(), label);
-
-        public static Isotope<Unit> assert(bool fact, string label) =>
-            fact ? pure(unit) : fail<Unit>(label);
-
-        public static Isotope<Unit> assertElementHasText(string cssSelector, string expected) =>
-            assertElementHasText(By.CssSelector(cssSelector), expected);
-
-        public static Isotope<Unit> assertElementHasText(By selector, string expected) =>
-            from el in findElement(selector)
-            from re in assertElementHasText(el, expected)
+            from _ in assert<Env>(f, label)
             select unit;
 
-        public static Isotope<Unit> assertElementHasText(IWebElement el, string expected) =>
-            from _ in assertElementIsDisplayed(el)
-            from re in assert(hasText(el, expected), $@"Expected element ""{el}"" to have text ""{expected}"" but it was ""{el.Text}""")
+        public static Isotope<Env, Unit> assert<Env>(Func<bool> fact, string label) =>
+            assert<Env>(fact(), label);
+
+        public static Isotope<Env, Unit> assert<Env>(bool fact, string label) =>
+            fact ? pure<Env, Unit>(unit) : fail<Env, Unit>(label);
+
+        public static Isotope<Env, Unit> assertElementHasText<Env>(string cssSelector, string expected) =>
+            assertElementHasText<Env>(By.CssSelector(cssSelector), expected);
+
+        public static Isotope<Env, Unit> assertElementHasText<Env>(By selector, string expected) =>
+            from el in findElement<Env>(selector)
+            from re in assertElementHasText<Env>(el, expected)
             select unit;
 
-        public static Isotope<Unit> assertElementIsDisplayed(string cssSelector) =>
-            assertElementIsDisplayed(By.CssSelector(cssSelector));
+        public static Isotope<Env, Unit> assertElementHasText<Env>(IWebElement el, string expected) =>
+            from _ in assertElementIsDisplayed<Env>(el)
+            from re in assert(hasText<Env>(el, expected), $@"Expected element ""{el}"" to have text ""{expected}"" but it was ""{el.Text}""")
+            select unit;
 
-        public static Isotope<Unit> assertElementIsDisplayed(By selector) =>
-            assert(displayed(selector), $@"Expected selector ""{selector}"" to be displayed.");
+        public static Isotope<Env, Unit> assertElementIsDisplayed<Env>(string cssSelector) =>
+            assertElementIsDisplayed<Env>(By.CssSelector(cssSelector));
 
-        public static Isotope<Unit> assertElementIsDisplayed(IWebElement el) =>
-            assert(displayed(el), $@"Expected element ""{el}"" to be displayed.");
+        public static Isotope<Env, Unit> assertElementIsDisplayed<Env>(By selector) =>
+            assert(displayed<Env>(selector), $@"Expected selector ""{selector}"" to be displayed.");
+
+        public static Isotope<Env, Unit> assertElementIsDisplayed<Env>(IWebElement el) =>
+            assert(displayed<Env>(el), $@"Expected element ""{el}"" to be displayed.");
     }
 }

--- a/src/Isotope80/Isotope80.csproj
+++ b/src/Isotope80/Isotope80.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>Isotope79</AssemblyTitle>
+    <AssemblyTitle>Isotope80</AssemblyTitle>
     <Authors>Medical Management Systems</Authors>
     <Company />
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Isotope80/Isotope80.csproj
+++ b/src/Isotope80/Isotope80.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="LanguageExt.CodeGen" Version="3.3.47" />
     <PackageReference Include="LanguageExt.Core" Version="3.3.47" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="84.0.4147.3001" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added reader-monad behaviour to the Isotope delegate.  Now has signature:

`public delegate IsotopeState<A> Isotope<Env, A>(Env env, IsotopeState state);`

**Updates**
These properties had to be converted to methods, to support the generic parameter:

- get
- unitM
- url
- webDriver
- getScreenShot
- disposeWebDriver
- defaultWait
- defaultInteval
- popLog

Fixed careers test, to expect "/jobs-at-meddbase/" instead of "careers"
Switched to use "Selenium.WebDriver.ChromeDriver" nuget package
Set AssemblyTitle to "Isotope80"
	
**Additions**

- public static Isotope<Env, Env> ask<Env>()
- public static Isotope<Env, R> asks<Env, R>(Func<Env, R> f)
- public static Isotope<Env, Unit> setWindowSize<Env>(Size size) 
- Environment tests

**Observations**

- waitUntilClickable does not use its "timeout" parameter