### PR TITLE
Refactor of Isotope monad

### DIFF
--- a/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
+++ b/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="LanguageExt.Core" Version="3.5.20-beta" />
     <PackageReference Include="Selenium.Chrome.WebDriver" Version="81.0.0" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
+++ b/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LanguageExt.Core" Version="3.3.47" />
+    <PackageReference Include="LanguageExt.Core" Version="3.5.20-beta" />
     <PackageReference Include="Selenium.Chrome.WebDriver" Version="81.0.0" />
   </ItemGroup>
 

--- a/samples/Isotope80.Samples.Console/Meddbase.cs
+++ b/samples/Isotope80.Samples.Console/Meddbase.cs
@@ -9,10 +9,10 @@ namespace Isotope80.Samples.Console
     {
         public static Isotope<Unit> GoToDesktopSite =>
             context("Go to Desktop Site",
-                    from _1 in log("Update Window Size")
-                    from _2 in setWindowSize(1280,960)
-                    from _3 in nav("https://www.meddbase.com")
-                    select unit);
+                from _1 in info("Update Window Size")
+                from _2 in setWindowSize(1280,960)
+                from _3 in nav("https://www.meddbase.com")
+                select unit);
 
         public static Isotope<Unit> WaitThenClick(By selector) =>
             from el in waitUntilClickable(selector)

--- a/samples/Isotope80.Samples.Console/Program.cs
+++ b/samples/Isotope80.Samples.Console/Program.cs
@@ -3,6 +3,7 @@ using System;
 using LanguageExt;
 using LanguageExt.Common;
 using static System.Console;
+using static Isotope80.Isotope;
 
 namespace Isotope80.Samples.Console
 {
@@ -13,8 +14,7 @@ namespace Isotope80.Samples.Console
             Action<string, int> consoleLogger =
                 (x, y) => WriteLine(new string('\t', y) + x);
 
-            (var state, var value) = Meddbase.GoToPageAndOpenCareers.Run(
-                new ChromeDriver(), 
+            (var state, var value) = withChromeDriver(Meddbase.GoToPageAndOpenCareers).Run(
                     IsotopeSettings.Create(
                         loggingAction: consoleLogger));
             

--- a/samples/Isotope80.Samples.Console/Program.cs
+++ b/samples/Isotope80.Samples.Console/Program.cs
@@ -2,6 +2,7 @@
 using System;
 using LanguageExt;
 using LanguageExt.Common;
+using static LanguageExt.Prelude;
 using static System.Console;
 using static Isotope80.Isotope;
 
@@ -11,12 +12,9 @@ namespace Isotope80.Samples.Console
     {
         static void Main(string[] args)
         {
-            Action<string, int> consoleLogger =
-                (x, y) => WriteLine(new string('\t', y) + x);
-
-            (var state, var value) = withChromeDriver(Meddbase.GoToPageAndOpenCareers).Run(
-                    IsotopeSettings.Create(
-                        loggingAction: consoleLogger));
+            var stgs = IsotopeSettings.Create();
+            stgs.LogStream.Subscribe(x => WriteLine(x));
+            (var state, var value) = withChromeDriver(Meddbase.GoToPageAndOpenCareers).Run(stgs);
             
             Clear();
             

--- a/samples/Isotope80.Samples.Console/Program.cs
+++ b/samples/Isotope80.Samples.Console/Program.cs
@@ -1,5 +1,7 @@
 ﻿using OpenQA.Selenium.Chrome;
 using System;
+using LanguageExt;
+using LanguageExt.Common;
 using static System.Console;
 
 namespace Isotope80.Samples.Console
@@ -20,15 +22,19 @@ namespace Isotope80.Samples.Console
             
             WriteLine("Current Vacancies:\n");
 
-            state.Error.Match(
-                Some: x => WriteLine($"ERROR: {x}"),
-                None: () => value.Iter(x => WriteLine(x)));
-
+            if (state.Error.IsEmpty)
+            {
+                value.Iter(x => WriteLine(x));
+            }
+            else
+            {
+                WriteLine($"ERROR: {state.Error.Head}");
+            }
+            
             WriteLine("\n\nLogs:\n");
-
             WriteLine(state.Log.ToString());
-
             WriteLine();
         }
+      
     }
 }

--- a/samples/Isotope80.Samples.UnitTests/Careers.cs
+++ b/samples/Isotope80.Samples.UnitTests/Careers.cs
@@ -65,7 +65,7 @@ namespace Isotope80.Samples.UnitTests
             Action<Error, Log> xunitOutput = 
                 (x,y) => output.WriteLine(y.ToString());
 
-            (var state, var value) = iso.RunAndThrowOnError(new ChromeDriver(), settings: IsotopeSettings.Create(failureAction: xunitOutput));
+            (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: IsotopeSettings.Create(failureAction: xunitOutput));
         }
     }
 }

--- a/samples/Isotope80.Samples.UnitTests/Careers.cs
+++ b/samples/Isotope80.Samples.UnitTests/Careers.cs
@@ -23,10 +23,10 @@ namespace Isotope80.Samples.UnitTests
 
         public static Isotope<Unit> GoToDesktopSite =>
             context("Go to Desktop Site",
-                    from _1 in log("Update Window Size")
-                    from _2 in setWindowSize(1280, 960)
-                    from _3 in nav("https://www.meddbase.com")
-                    select unit);
+                from _1 in info("Update Window Size")
+                from _2 in setWindowSize(1280, 960)
+                from _3 in nav("https://www.meddbase.com")
+                select unit);
 
         public static Isotope<Unit> WaitThenClick(By selector) =>
             from el in waitUntilClickable(selector)
@@ -62,10 +62,11 @@ namespace Isotope80.Samples.UnitTests
                       from _2  in assert(url == expected, $"Expected URL to be {expected} but it was {url}")
                       select unit;
            
-            Action<Error, Log> xunitOutput = 
-                (x,y) => output.WriteLine(y.ToString());
-
-            (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: IsotopeSettings.Create(failureAction: xunitOutput));
+            var stgs = IsotopeSettings.Create();
+            stgs.LogStream.Subscribe(x => output.WriteLine(x.ToString()));
+            stgs.ErrorStream.Subscribe(x => output.WriteLine(x.ToString()));
+ 
+            (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: IsotopeSettings.Create());
         }
     }
 }

--- a/samples/Isotope80.Samples.UnitTests/Careers.cs
+++ b/samples/Isotope80.Samples.UnitTests/Careers.cs
@@ -4,6 +4,7 @@ using Xunit;
 using static Isotope80.Isotope;
 using static Isotope80.Assertions;
 using LanguageExt;
+using LanguageExt.Common;
 using static LanguageExt.Prelude;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -61,7 +62,7 @@ namespace Isotope80.Samples.UnitTests
                       from _2  in assert(url == expected, $"Expected URL to be {expected} but it was {url}")
                       select unit;
            
-            Action<string, Log> xunitOutput = 
+            Action<Error, Log> xunitOutput = 
                 (x,y) => output.WriteLine(y.ToString());
 
             (var state, var value) = iso.RunAndThrowOnError(new ChromeDriver(), settings: IsotopeSettings.Create(failureAction: xunitOutput));

--- a/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
+++ b/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
@@ -1,0 +1,67 @@
+using OpenQA.Selenium.Chrome;
+using System;
+using LanguageExt;
+using LanguageExt.Common;
+using Xunit;
+using static LanguageExt.Prelude;
+using static System.Console;
+using static Isotope80.Isotope;
+
+namespace Isotope80.Samples.UnitTests
+{
+    public class LoggingTests
+    {
+        [Fact]
+        public void TestNestedContextualLogs()
+        {
+            Seq<string> expected = Seq(
+                "Test 1",
+                "Info for test 1",
+                "More info for test 1",
+                "\tTest 1.SubTest 1",
+                "\tInfo for test Test 1.SubTest 1",
+                "\tMore info for test Test 1.SubTest 1",
+                "\tTest 1.SubTest 2",
+                "\tInfo for test Test 1.SubTest 2",
+                "\tMore info for test Test 1.SubTest 2");
+            
+            Seq<string> logs = default;
+            
+            var stgs = IsotopeSettings.Create();
+            stgs.LogStream.Subscribe(x => logs = logs.Add(x.ToString()));
+
+            var iso2 = context("Test 1",
+                               from a in info("Info for test 1")
+                               from b in info("More info for test 1")
+                               from c in context("Test 1.SubTest 1",
+                                                 from d in info("Info for test Test 1.SubTest 1")
+                                                 from e in info("More info for test Test 1.SubTest 1")
+                                                 select unit)
+                               from f in context("Test 1.SubTest 2",
+                                                 from g in warn("Info for test Test 1.SubTest 2")
+                                                 from h in warn("More info for test Test 1.SubTest 2")
+                                                 select unit)
+                               select unit);
+                                              
+                                
+            (var state2, var value2) = iso2.Run(stgs);
+
+            Assert.True(logs == expected);
+        }
+        
+        [Fact]
+        public void TestNestedContextualErrors()
+        {
+            var stgs = IsotopeSettings.Create();
+
+            var iso = context("Chrome",
+                           context("Start Page",
+                                context("Patient tile",
+                                     fail<Unit>("element not found"))));
+                                
+            (var state, var value) = iso.Run(stgs);
+
+            Assert.True(state.Error.Head.Message == "element not found (Chrome → Start Page → Patient tile)");
+        }
+    }
+}

--- a/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
+++ b/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
@@ -15,33 +15,36 @@ namespace Isotope80.Samples.UnitTests
         public void TestNestedContextualLogs()
         {
             Seq<string> expected = Seq(
-                "Test 1",
-                "Info for test 1",
-                "More info for test 1",
-                "\tTest 1.SubTest 1",
-                "\tInfo for test Test 1.SubTest 1",
-                "\tMore info for test Test 1.SubTest 1",
-                "\tTest 1.SubTest 2",
-                "\tInfo for test Test 1.SubTest 2",
-                "\tMore info for test Test 1.SubTest 2");
+                "Info log",
+                "\tTest 1",
+                "\tInfo for test 1",
+                "\tMore info for test 1",
+                "\t\tTest 1.SubTest 1",
+                "\t\tInfo for test Test 1.SubTest 1",
+                "\t\tMore info for test Test 1.SubTest 1",
+                "\t\tTest 1.SubTest 2",
+                "\t\tInfo for test Test 1.SubTest 2",
+                "\t\tMore info for test Test 1.SubTest 2");
             
             Seq<string> logs = default;
             
             var stgs = IsotopeSettings.Create();
             stgs.LogStream.Subscribe(x => logs = logs.Add(x.ToString()));
 
-            var iso2 = context("Test 1",
-                               from a in info("Info for test 1")
-                               from b in info("More info for test 1")
-                               from c in context("Test 1.SubTest 1",
-                                                 from d in info("Info for test Test 1.SubTest 1")
-                                                 from e in info("More info for test Test 1.SubTest 1")
-                                                 select unit)
-                               from f in context("Test 1.SubTest 2",
-                                                 from g in warn("Info for test Test 1.SubTest 2")
-                                                 from h in warn("More info for test Test 1.SubTest 2")
-                                                 select unit)
-                               select unit);
+            var iso2 = from _ in info("Info log")
+                       from r in context("Test 1",
+                                         from a in info("Info for test 1")
+                                         from b in info("More info for test 1")
+                                         from c in context("Test 1.SubTest 1",
+                                                           from d in info("Info for test Test 1.SubTest 1")
+                                                           from e in info("More info for test Test 1.SubTest 1")
+                                                           select unit)
+                                         from f in context("Test 1.SubTest 2",
+                                                           from g in warn("Info for test Test 1.SubTest 2")
+                                                           from h in warn("More info for test Test 1.SubTest 2")
+                                                           select unit)
+                                         select unit)
+                       select r;
                                               
                                 
             (var state2, var value2) = iso2.Run(stgs);

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -1246,18 +1246,18 @@ namespace Isotope80
             select unit;
 
         public static Isotope<IWebElement> waitUntilClickable(By selector, TimeSpan timeout) =>
-            from _1 in log($"Waiting until clickable: {selector}")
+            from _1 in info($"Waiting until clickable: {selector}")
             from el in waitUntilElementExists(selector)
             from _2 in waitUntilClickable(el, timeout)
             select el;
 
         public static Isotope<Unit> waitUntilClickable(IWebElement el, TimeSpan timeout) =>
             from _ in waitUntil(
-                        from _1a in log($"Checking clickability " + el.PrettyPrint())
+                        from _1a in info($"Checking clickability " + el.PrettyPrint())
                         from d in displayed(el)
                         from e in enabled(el)
                         from o in obscured(el)
-                        from _2a in log($"Displayed: {d}, Enabled: {e}, Obscured: {o}")
+                        from _2a in info($"Displayed: {d}, Enabled: {e}, Obscured: {o}")
                         select d && e && (!o),
                         x => !x)
             select unit;
@@ -1694,9 +1694,9 @@ namespace Isotope80
             let coords = element.Location
             let x = coords.X + (int)Math.Floor((double)(element.Size.Width / 2))
             let y = coords.Y + (int)Math.Floor((double)(element.Size.Height / 2))
-            from _ in log($"X: {x}, Y: {y}")
+            from _ in info($"X: {x}, Y: {y}")
             from top in pure((IWebElement)jsExec.ExecuteScript($"return document.elementFromPoint({x}, {y});"))
-            from _1  in log($"Target: {element.PrettyPrint()}, Top: {top.PrettyPrint()}")
+            from _1  in info($"Target: {element.PrettyPrint()}, Top: {top.PrettyPrint()}")
             select !element.Equals(top);
 
         /// <summary>

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -110,9 +110,13 @@ namespace Isotope80
             new Isotope<A>(s =>
             {
                 var l = lhs.Invoke(s);
-                return l.IsFaulted
+                var r = l.IsFaulted
                            ? rhs.Invoke(s)
                            : l;
+
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
             });
 
         /// <summary>
@@ -416,9 +420,13 @@ namespace Isotope80
         public static Isotope<Env, A> operator |(Isotope<Env, A> lhs, Isotope<Env, A> rhs) =>
             new Isotope<Env, A>((e, s) => {
                                     var l = lhs.Invoke(e, s);
-                                    return l.IsFaulted
-                                               ? rhs.Invoke(e, s)
-                                               : l;
+                                    var r = l.IsFaulted
+                                                ? rhs.Invoke(e, s)
+                                                : l;
+
+                                    return r.IsFaulted
+                                               ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                                               : r;
                                 });
 
         /// <summary>
@@ -719,9 +727,13 @@ namespace Isotope80
             new IsotopeAsync<A>(async s =>
             {
                 var l = await lhs.Invoke(s);
-                return l.IsFaulted
-                           ? await rhs.Invoke(s)
-                           : l;
+                var r = l.IsFaulted
+                            ? await rhs.Invoke(s)
+                            : l;
+
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
             });
 
         /// <summary>
@@ -1041,9 +1053,13 @@ namespace Isotope80
         public static IsotopeAsync<Env, A> operator |(IsotopeAsync<Env, A> lhs, IsotopeAsync<Env, A> rhs) =>
             new IsotopeAsync<Env, A>(async (e, s) => {
                                          var l = await lhs.Invoke(e, s);
-                                         return l.IsFaulted
-                                                    ? await rhs.Invoke(e, s)
-                                                    : l;
+                                         var r = l.IsFaulted
+                                                     ? await rhs.Invoke(e, s)
+                                                     : l;
+
+                                         return r.IsFaulted
+                                                    ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                                                    : r;
                                      });
 
         /// <summary>

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -10,6 +10,7 @@ using LanguageExt.Common;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Edge;
 using OpenQA.Selenium.Firefox;
+using OpenQA.Selenium.IE;
 using static LanguageExt.Prelude;
 
 namespace Isotope80
@@ -274,6 +275,118 @@ namespace Isotope80
                                                select rs);
 
         /// <summary>
+        /// Run the isotope provided with the web-driver context
+        /// </summary>
+        public static Isotope<Unit> withWebDrivers<A>(Isotope<A> ma, params WebDriverSelect[] webDrivers) =>
+            new Isotope<Unit>(s => {
+                           
+                Seq<Error> errors = Empty;
+                
+                foreach (var webDriver in webDrivers)
+                {
+                    var (d, nm) = webDriver switch
+                            {
+                                WebDriverSelect.Chrome           => (new ChromeDriver() as IWebDriver, "Chrome"),
+                                WebDriverSelect.Firefox          => (new FirefoxDriver(), "Firefox"),
+                                WebDriverSelect.Edge             => (new EdgeDriver(), "Edge"),
+                                WebDriverSelect.InternetExplorer => (new InternetExplorerDriver(), "IE"),
+                                _                                => throw new NotSupportedException($"Web-driver not supported: {webDriver}")
+                            };
+
+                    // Run with the web-driver
+                    var r = withWebDriver(d, ma).Invoke(s);
+
+                    // Collect the errors, prefix them with the name of the browser
+                    errors = errors + r.State.Error.Map(e => Error.New($"[{nm}] {e.Message}", e.Exception.IsSome ? (Exception) e : null));
+                }
+                return new IsotopeState<Unit>(default, s.With(Error: errors));
+            });
+
+        /// <summary>
+        /// Run the isotope provided with the web-driver context
+        /// </summary>
+        public static Isotope<Env, Unit> withWebDrivers<Env, A>(Isotope<Env, A> ma, params WebDriverSelect[] webDrivers) =>
+            new Isotope<Env, Unit>((e, s) => {
+                           
+                Seq<Error> errors = Empty;
+                
+                foreach (var webDriver in webDrivers)
+                {
+                    var (d, nm) = webDriver switch
+                            {
+                                WebDriverSelect.Chrome           => (new ChromeDriver() as IWebDriver, "Chrome"),
+                                WebDriverSelect.Firefox          => (new FirefoxDriver(), "Firefox"),
+                                WebDriverSelect.Edge             => (new EdgeDriver(), "Edge"),
+                                WebDriverSelect.InternetExplorer => (new InternetExplorerDriver(), "IE"),
+                                _                                => throw new NotSupportedException($"Web-driver not supported: {webDriver}")
+                            };
+
+                    // Run with the web-driver
+                    var r = withWebDriver(d, ma).Invoke(e, s);
+
+                    // Collect the errors, prefix them with the name of the browser
+                    errors = errors + r.State.Error.Map(e => Error.New($"[{nm}] {e.Message}", e.Exception.IsSome ? (Exception) e : null));
+                }
+                return new IsotopeState<Unit>(default, s.With(Error: errors));
+            });
+
+        /// <summary>
+        /// Run the isotope provided with the web-driver context
+        /// </summary>
+        public static IsotopeAsync<Unit> withWebDrivers<A>(IsotopeAsync<A> ma, params WebDriverSelect[] webDrivers) =>
+            new IsotopeAsync<Unit>(async s => {
+                           
+                Seq<Error> errors = Empty;
+                
+                foreach (var webDriver in webDrivers)
+                {
+                    var (d, nm) = webDriver switch
+                            {
+                                WebDriverSelect.Chrome           => (new ChromeDriver() as IWebDriver, "Chrome"),
+                                WebDriverSelect.Firefox          => (new FirefoxDriver(), "Firefox"),
+                                WebDriverSelect.Edge             => (new EdgeDriver(), "Edge"),
+                                WebDriverSelect.InternetExplorer => (new InternetExplorerDriver(), "IE"),
+                                _                                => throw new NotSupportedException($"Web-driver not supported: {webDriver}")
+                            };
+
+                    // Run with the web-driver
+                    var r = await withWebDriver(d, ma).Invoke(s).ConfigureAwait(false);
+
+                    // Collect the errors, prefix them with the name of the browser
+                    errors = errors + r.State.Error.Map(e => Error.New($"[{nm}] {e.Message}", e.Exception.IsSome ? (Exception) e : null));
+                }
+                return new IsotopeState<Unit>(default, s.With(Error: errors));
+            });
+
+        /// <summary>
+        /// Run the isotope provided with the web-driver context
+        /// </summary>
+        public static IsotopeAsync<Env, Unit> withWebDrivers<Env, A>(IsotopeAsync<Env, A> ma, params WebDriverSelect[] webDrivers) =>
+            new IsotopeAsync<Env, Unit>(async (e, s) => {
+                           
+                Seq<Error> errors = Empty;
+                
+                foreach (var webDriver in webDrivers)
+                {
+                    var (d, nm) = webDriver switch
+                            {
+                                WebDriverSelect.Chrome           => (new ChromeDriver() as IWebDriver, "Chrome"),
+                                WebDriverSelect.Firefox          => (new FirefoxDriver(), "Firefox"),
+                                WebDriverSelect.Edge             => (new EdgeDriver(), "Edge"),
+                                WebDriverSelect.InternetExplorer => (new InternetExplorerDriver(), "IE"),
+                                _                                => throw new NotSupportedException($"Web-driver not supported: {webDriver}")
+                            };
+
+                    // Run with the web-driver
+                    var r = await withWebDriver(d, ma).Invoke(e, s);
+
+                    // Collect the errors, prefix them with the name of the browser
+                    errors = errors + r.State.Error.Map(e => Error.New($"[{nm}] {e.Message}", e.Exception.IsSome ? (Exception) e : null));
+                }
+                return new IsotopeState<Unit>(default, s.With(Error: errors));
+            });
+        
+        /// <summary>
         /// Run the isotope provided with Chrome web-driver
         /// </summary>
         public static Isotope<A> withChromeDriver<A>(Isotope<A> ma) =>
@@ -290,6 +403,12 @@ namespace Isotope80
         /// </summary>
         public static Isotope<A> withFirefoxDriver<A>(Isotope<A> ma) =>
             withWebDriver(new FirefoxDriver(), ma);
+
+        /// <summary>
+        /// Run the isotope provided with Internet Explorer web-driver
+        /// </summary>
+        public static Isotope<A> withInternetExplorerDriver<A>(Isotope<A> ma) =>
+            withWebDriver(new InternetExplorerDriver(), ma);
 
         /// <summary>
         /// Run the isotope provided with Chrome web-driver
@@ -310,6 +429,12 @@ namespace Isotope80
             withWebDriver(new FirefoxDriver(), ma);
         
         /// <summary>
+        /// Run the isotope provided with Internet Explorer web-driver
+        /// </summary>
+        public static Isotope<Env, A> withInternetExplorerDriver<Env, A>(Isotope<Env, A> ma) =>
+            withWebDriver(new InternetExplorerDriver(), ma);
+
+        /// <summary>
         /// Run the isotope provided with Chrome web-driver
         /// </summary>
         public static IsotopeAsync<A> withChromeDriver<A>(IsotopeAsync<A> ma) =>
@@ -326,6 +451,12 @@ namespace Isotope80
         /// </summary>
         public static IsotopeAsync<A> withFirefoxDriver<A>(IsotopeAsync<A> ma) =>
             withWebDriver(new FirefoxDriver(), ma);
+                
+        /// <summary>
+        /// Run the isotope provided with Internet Explorer web-driver
+        /// </summary>
+        public static IsotopeAsync<A> withInternetExplorerDriver<A>(IsotopeAsync<A> ma) =>
+            withWebDriver(new InternetExplorerDriver(), ma);
         
         /// <summary>
         /// Run the isotope provided with Chrome web-driver
@@ -344,6 +475,12 @@ namespace Isotope80
         /// </summary>
         public static IsotopeAsync<Env, A> withFirefoxDriver<Env, A>(IsotopeAsync<Env, A> ma) =>
             withWebDriver(new FirefoxDriver(), ma);
+                
+        /// <summary>
+        /// Run the isotope provided with Internet Explorer web-driver
+        /// </summary>
+        public static IsotopeAsync<Env, A> withInternetExplorerDriver<Env, A>(IsotopeAsync<Env, A> ma) =>
+            withWebDriver(new InternetExplorerDriver(), ma);
         
         /// <summary>
         /// Set the window size of the browser

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -237,33 +237,41 @@ namespace Isotope80
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static Isotope<A> withWebDriver<A>(IWebDriver driver, Isotope<A> ma) =>
-            use(driver, disposeWebDriver, d => from _ in setWebDriver(driver)  
-                                               from r in ma
-                                               select r);
+            use(driver, disposeWebDriver, d => from od in webDriver
+                                               from _1 in setWebDriver(driver)  
+                                               from rs in ma
+                                               from _2 in setWebDriver(od)  
+                                               select rs);
 
         /// <summary>
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static Isotope<Env, A> withWebDriver<Env, A>(IWebDriver driver, Isotope<Env, A> ma) =>
-            use(driver, disposeWebDriver, d => from _ in setWebDriver(driver)  
-                                               from r in ma
-                                               select r);
+            use(driver, disposeWebDriver, d => from od in webDriver
+                                               from _1 in setWebDriver(driver)  
+                                               from rs in ma
+                                               from _2 in setWebDriver(od)  
+                                               select rs);
 
         /// <summary>
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static IsotopeAsync<A> withWebDriver<A>(IWebDriver driver, IsotopeAsync<A> ma) =>
-            use(driver, disposeWebDriver, d => from _ in setWebDriver(driver)  
-                                               from r in ma
-                                               select r);
+            use(driver, disposeWebDriver, d => from od in webDriver
+                                               from _1 in setWebDriver(driver)  
+                                               from rs in ma
+                                               from _2 in setWebDriver(od)  
+                                               select rs);
 
         /// <summary>
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static IsotopeAsync<Env, A> withWebDriver<Env, A>(IWebDriver driver, IsotopeAsync<Env, A> ma) =>
-            use(driver, disposeWebDriver, d => from _ in setWebDriver(driver)  
-                                               from r in ma
-                                               select r);
+            use(driver, disposeWebDriver, d => from od in webDriver
+                                               from _1 in setWebDriver(driver)  
+                                               from rs in ma
+                                               from _2 in setWebDriver(od)  
+                                               select rs);
 
         /// <summary>
         /// Run the isotope provided with Chrome web-driver

--- a/src/Isotope80/Isotope80.csproj
+++ b/src/Isotope80/Isotope80.csproj
@@ -27,8 +27,8 @@
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-codegen" Version="0.6.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="LanguageExt.CodeGen" Version="3.3.47" />
-    <PackageReference Include="LanguageExt.Core" Version="3.3.47" />
+    <PackageReference Include="LanguageExt.CodeGen" Version="3.5.20-beta" />
+    <PackageReference Include="LanguageExt.Core" Version="3.5.20-beta" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
   </ItemGroup>

--- a/src/Isotope80/Isotope80.csproj
+++ b/src/Isotope80/Isotope80.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="LanguageExt.Core" Version="3.5.20-beta" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Isotope80/IsotopeAsync_A.cs
+++ b/src/Isotope80/IsotopeAsync_A.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using OpenQA.Selenium;
+using static LanguageExt.Prelude;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Asynchronous, environment-free, isotope computation
+    /// </summary>
+    /// <typeparam name="A">Bound value</typeparam>
+    public struct IsotopeAsync<A>
+    {
+        readonly Func<IsotopeState, ValueTask<IsotopeState<A>>> Thunk;
+        
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="thunk">Thunk</param>
+        public IsotopeAsync(Func<IsotopeState, ValueTask<IsotopeState<A>>> thunk) =>
+            Thunk = thunk;
+
+        /// <summary>
+        /// Invoke the computation
+        /// </summary>
+        /// <param name="state">State</param>
+        /// <returns>Result of invoking the isotope computation</returns>
+        internal async ValueTask<IsotopeState<A>> Invoke(IsotopeState state)
+        {
+            try
+            {
+                if (Thunk == null)
+                {
+                    throw new InvalidOperationException("Isotope computation not initialised");
+                }
+                return await Thunk(state).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                return new IsotopeState<A>(default, state.AddError(Error.New(e)));
+            }
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public async ValueTask<(IsotopeState state, A value)> Run(IsotopeSettings settings = null)
+        {
+            var res = await Invoke(IsotopeState.Empty.With(Settings: settings)).ConfigureAwait(false);
+            if (res.State.Settings.DisposeOnCompletion)
+            {
+                res.State.DisposeWebDriver();
+            }
+            return(res.State, res.Value);
+        }
+        
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public async ValueTask<(IsotopeState state, A value)> RunAndThrowOnError(IsotopeSettings settings = null)
+        {
+            var (state, value) = await Run(settings).ConfigureAwait(false);
+            state.IfFailedThrow();
+            return (state, value);
+        }
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator IsotopeAsync<A>(Isotope<A> ma) =>
+            new IsotopeAsync<A>(state => new ValueTask<IsotopeState<A>>(ma.Invoke(state)));
+        
+        /// <summary>
+        /// Or operator - evaluates the left hand side, if it fails, it ignores the error and evaluates the right hand side
+        /// </summary>
+        public static IsotopeAsync<A> operator |(IsotopeAsync<A> lhs, IsotopeAsync<A> rhs) => 
+            new IsotopeAsync<A>(async s =>
+            {
+                var l = await lhs.Invoke(s).ConfigureAwait(false);
+                var r = l.IsFaulted
+                            ? await rhs.Invoke(s).ConfigureAwait(false)
+                            : l;
+
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
+            });
+
+        /// <summary>
+        /// Lift the pure value into the monadic space 
+        /// </summary>
+        public static IsotopeAsync<A> Pure(A value) =>
+            new IsotopeAsync<A>(s => new ValueTask<IsotopeState<A>>(new IsotopeState<A>(value, s)));
+        
+        /// <summary>
+        /// Lift the error into the monadic space 
+        /// </summary>
+        public static IsotopeAsync<A> Fail(Error error) =>
+            new IsotopeAsync<A>(s => new ValueTask<IsotopeState<A>>(new IsotopeState<A>(default(A), s.AddError(error))));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> Bind<B>(Func<A, Isotope<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<B>(async state => 
+            { 
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<Env, B>(Func<A, Isotope<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> Bind<B>(Func<A, IsotopeAsync<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<B>(async state => 
+            { 
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(s.State).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<Env, B>(Func<A, IsotopeAsync<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(env, s.State).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> SelectMany<B>(Func<A, Isotope<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<Env, B>(Func<A, Isotope<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> SelectMany<B>(Func<A, IsotopeAsync<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<Env, B>(Func<A, IsotopeAsync<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<C> SelectMany<B, C>(Func<A, Isotope<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<Env, B, C>(Func<A, Isotope<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<C> SelectMany<B, C>(Func<A, IsotopeAsync<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<Env, B, C>(Func<A, IsotopeAsync<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public IsotopeAsync<B> Map<B>(Func<A, B> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<B>(async state => 
+            {
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return new IsotopeState<B>(f(s.Value), s.State);
+            });
+        }
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public IsotopeAsync<B> Select<B>(Func<A, B> f) =>
+            Map(f);        
+    
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<A> MapFail(Func<Seq<Error>, Seq<Error>> f)
+        {
+            var self = this;
+            return new IsotopeAsync<A>(
+                async s => {
+                    var r = await self.Invoke(s).ConfigureAwait(false);
+                    return r.IsFaulted
+                               ? new IsotopeState<A>(default, r.State.With(Error: f(r.State.Error)))
+                               : r;
+                });
+        }
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<B> BiMap<B>(Func<A, B> Succ,  Func<Seq<Error>, Seq<Error>> Fail)
+        {
+            var self = this;
+            return new IsotopeAsync<B>(
+                async s => {
+                    var r = await self.Invoke(s).ConfigureAwait(false);
+                    return r.IsFaulted
+                               ? new IsotopeState<B>(default, r.State.With(Error: Fail(r.State.Error)))
+                               : new IsotopeState<B>(Succ(r.Value), r.State);
+                });
+        }
+        
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<A> MapFail(Func<Seq<Error>, Error> f) =>
+            MapFail(s => Seq1(f(s)));
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<B> BiMap<B>(Func<A, B> Succ, Func<Seq<Error>, Error> Fail) =>
+            BiMap(Succ, s => Seq1(Fail(s)));
+    }
+}

--- a/src/Isotope80/IsotopeAsync_A.cs
+++ b/src/Isotope80/IsotopeAsync_A.cs
@@ -52,10 +52,6 @@ namespace Isotope80
         public async ValueTask<(IsotopeState state, A value)> Run(IsotopeSettings settings = null)
         {
             var res = await Invoke(IsotopeState.Empty.With(Settings: settings)).ConfigureAwait(false);
-            if (res.State.Settings.DisposeOnCompletion)
-            {
-                res.State.DisposeWebDriver();
-            }
             return(res.State, res.Value);
         }
         

--- a/src/Isotope80/IsotopeAsync_Env_A.cs
+++ b/src/Isotope80/IsotopeAsync_Env_A.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using OpenQA.Selenium;
+using static LanguageExt.Prelude;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Asynchronous isotope computation with an environment
+    /// </summary>
+    /// <typeparam name="Env">Environment</typeparam>
+    /// <typeparam name="A">Bound value</typeparam>
+    public struct IsotopeAsync<Env, A>
+    {
+        readonly Func<Env, IsotopeState, ValueTask<IsotopeState<A>>> Thunk;
+        
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="thunk">Thunk</param>
+        public IsotopeAsync(Func<Env, IsotopeState, ValueTask<IsotopeState<A>>> thunk) =>
+            Thunk = thunk;
+
+        /// <summary>
+        /// Invoke the computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="state">State</param>
+        /// <returns>Result of invoking the isotope computation</returns>
+        internal async ValueTask<IsotopeState<A>> Invoke(Env env, IsotopeState state)
+        {
+            try
+            {
+                if (Thunk == null)
+                {
+                    throw new InvalidOperationException("Isotope computation not initialised");
+                }
+                return await Thunk(env, state).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                return new IsotopeState<A>(default, state.AddError(Error.New(e)));
+            }
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public async ValueTask<(IsotopeState state, A value)> Run(Env env, IsotopeSettings settings = null)
+        {
+            var res = await Invoke(env, IsotopeState.Empty.With(Settings: settings)).ConfigureAwait(false);
+            if (res.State.Settings.DisposeOnCompletion)
+            {
+                res.State.DisposeWebDriver();
+            }
+
+            return (res.State, res.Value);
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public async ValueTask<(IsotopeState state, A value)> RunAndThrowOnError(Env env, IsotopeSettings settings = null)
+        {
+            var (state, value) = await Run(env, settings).ConfigureAwait(false);
+            state.IfFailedThrow();
+            return (state, value);
+        }
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator IsotopeAsync<Env, A>(Isotope<A> ma) =>
+            new IsotopeAsync<Env, A>((_, state) => new ValueTask<IsotopeState<A>>(ma.Invoke(state)));
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator IsotopeAsync<Env, A>(Isotope<Env, A> ma) =>
+            new IsotopeAsync<Env, A>((env, state) => new ValueTask<IsotopeState<A>>(ma.Invoke(env, state)));
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator IsotopeAsync<Env, A>(IsotopeAsync<A> ma) =>
+            new IsotopeAsync<Env, A>((_, state) => ma.Invoke(state));
+
+        /// <summary>
+        /// Or operator - evaluates the left hand side, if it fails, it ignores the error and evaluates the right hand side
+        /// </summary>
+        public static IsotopeAsync<Env, A> operator |(IsotopeAsync<Env, A> lhs, IsotopeAsync<Env, A> rhs) =>
+            new IsotopeAsync<Env, A>(async (e, s) => {
+                                         var l = await lhs.Invoke(e, s).ConfigureAwait(false);
+                                         var r = l.IsFaulted
+                                                     ? await rhs.Invoke(e, s).ConfigureAwait(false)
+                                                     : l;
+
+                                         return r.IsFaulted
+                                                    ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                                                    : r;
+                                     });
+
+        /// <summary>
+        /// Lift the pure value into the monadic space 
+        /// </summary>
+        public static IsotopeAsync<Env, A> Pure(A value) =>
+            new IsotopeAsync<Env, A>((e, s) => new ValueTask<IsotopeState<A>>(new IsotopeState<A>(value, s)));
+
+        /// <summary>
+        /// Lift the error into the monadic space 
+        /// </summary>
+        public static IsotopeAsync<Env, A> Fail(Error error) =>
+            new IsotopeAsync<Env, A>((e, s) => new ValueTask<IsotopeState<A>>(new IsotopeState<A>(default(A), s.AddError(error))));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, Isotope<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>( async (env, state) => 
+            { 
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, Isotope<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>( async (env, state) => 
+            { 
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, IsotopeAsync<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(s.State).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, IsotopeAsync<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(env, s.State).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, Isotope<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, Isotope<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, IsotopeAsync<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, IsotopeAsync<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, Isotope<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, Isotope<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, IsotopeAsync<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, IsotopeAsync<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public IsotopeAsync<Env, B> Map<B>(Func<A, B> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>( async (env, state) => 
+            {
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return new IsotopeState<B>(f(s.Value), s.State);
+            });
+        }
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public IsotopeAsync<Env, B> Select<B>(Func<A, B> f) =>
+            Map(f);
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<Env, A> MapFail(Func<Seq<Error>, Seq<Error>> f)
+        {
+            var self = this;
+            return new IsotopeAsync<Env, A>(
+                async (e, s) => {
+                    var r = await self.Invoke(e, s).ConfigureAwait(false);
+                    return r.IsFaulted
+                               ? new IsotopeState<A>(default, r.State.With(Error: f(r.State.Error)))
+                               : r;
+                });
+        }
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<Env, B> BiMap<B>(Func<A, B> Succ,  Func<Seq<Error>, Seq<Error>> Fail)
+        {
+            var self = this;
+            return new IsotopeAsync<Env, B>(
+                async (e, s) => {
+                    var r = await self.Invoke(e, s).ConfigureAwait(false);
+                    return r.IsFaulted
+                               ? new IsotopeState<B>(default, r.State.With(Error: Fail(r.State.Error)))
+                               : new IsotopeState<B>(Succ(r.Value), r.State);
+                });
+        }
+        
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<Env, A> MapFail(Func<Seq<Error>, Error> f) =>
+            MapFail(s => Seq1(f(s)));
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<Env, B> BiMap<B>(Func<A, B> Succ, Func<Seq<Error>, Error> Fail) =>
+            BiMap(Succ, s => Seq1(Fail(s)));
+    }
+}

--- a/src/Isotope80/IsotopeAsync_Env_A.cs
+++ b/src/Isotope80/IsotopeAsync_Env_A.cs
@@ -55,11 +55,6 @@ namespace Isotope80
         public async ValueTask<(IsotopeState state, A value)> Run(Env env, IsotopeSettings settings = null)
         {
             var res = await Invoke(env, IsotopeState.Empty.With(Settings: settings)).ConfigureAwait(false);
-            if (res.State.Settings.DisposeOnCompletion)
-            {
-                res.State.DisposeWebDriver();
-            }
-
             return (res.State, res.Value);
         }
 

--- a/src/Isotope80/IsotopeSettings.cs
+++ b/src/Isotope80/IsotopeSettings.cs
@@ -1,5 +1,6 @@
 ﻿using LanguageExt;
 using System;
+using LanguageExt.Common;
 
 namespace Isotope80
 {
@@ -10,8 +11,8 @@ namespace Isotope80
         private const bool defaultDisposeOnCompletion = true;
         public readonly Action<string, int> LoggingAction;
         private static Action<string, int> defaultLoggingAction = (x,y) => { };
-        public readonly Action<string, Log> FailureAction;
-        private static Action<string, Log> defaultFailureAction = (x, y) => { };
+        public readonly Action<Error, Log> FailureAction;
+        private static Action<Error, Log> defaultFailureAction = (x, y) => { };
         public readonly TimeSpan Wait;
         private static TimeSpan defaultWait = TimeSpan.FromSeconds(10);
         public readonly TimeSpan Interval;
@@ -20,7 +21,7 @@ namespace Isotope80
         private IsotopeSettings(
             bool disposeOnCompletion,
             Action<string, int> loggingAction,
-            Action<string, Log> failureAction,
+            Action<Error, Log> failureAction,
             TimeSpan wait,
             TimeSpan interval)
         {
@@ -34,7 +35,7 @@ namespace Isotope80
         public static IsotopeSettings Create(
             bool? disposeOnCompletion = null,
             Action<string, int> loggingAction = null,
-            Action<string, Log> failureAction = null,
+            Action<Error, Log> failureAction = null,
             TimeSpan? wait = null,
             TimeSpan? interval = null) =>
             new IsotopeSettings(
@@ -43,5 +44,11 @@ namespace Isotope80
                 failureAction ?? defaultFailureAction,
                 wait ?? defaultWait,
                 interval ?? defaultInterval);
+
+        static Action<Error, Log> MakeFail(Action<string, Log> f) =>
+            f == null
+                ? defaultFailureAction
+                : (Error err, Log log) => f(err.ToString(), log);
+
     }
 }

--- a/src/Isotope80/IsotopeSettings.cs
+++ b/src/Isotope80/IsotopeSettings.cs
@@ -1,54 +1,85 @@
 ﻿using LanguageExt;
 using System;
+using System.Reactive.Subjects;
 using LanguageExt.Common;
 
 namespace Isotope80
 {
+    /// <summary>
+    /// Common settings environment that is threaded through every Isotope computation
+    /// </summary>
     [With]
     public partial class IsotopeSettings
     {
-        public readonly bool DisposeOnCompletion;
-        private const bool defaultDisposeOnCompletion = true;
-        public readonly Action<string, int> LoggingAction;
-        private static Action<string, int> defaultLoggingAction = (x,y) => { };
-        public readonly Action<Error, Log> FailureAction;
-        private static Action<Error, Log> defaultFailureAction = (x, y) => { };
-        public readonly TimeSpan Wait;
+        /// <summary>
+        /// Default wait time
+        /// </summary>
         private static TimeSpan defaultWait = TimeSpan.FromSeconds(10);
-        public readonly TimeSpan Interval;
-        private static TimeSpan defaultInterval = TimeSpan.FromMilliseconds(500);
 
+        /// <summary>
+        /// Default interval
+        /// </summary>
+        private static TimeSpan defaultInterval = TimeSpan.FromMilliseconds(500);
+ 
+        /// <summary>
+        /// Errors
+        /// </summary>
+        public readonly Subject<Error> ErrorStream; 
+
+        /// <summary>
+        /// Errors
+        /// </summary>
+        public readonly Subject<LogOutput> LogStream;
+
+        /// <summary>
+        /// Wait time
+        /// </summary>
+        public readonly TimeSpan Wait;
+        
+        /// <summary>
+        /// Interval time
+        /// </summary>
+        public readonly TimeSpan Interval;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
         private IsotopeSettings(
-            bool disposeOnCompletion,
-            Action<string, int> loggingAction,
-            Action<Error, Log> failureAction,
+            Subject<Error> errorStream,
+            Subject<LogOutput> logStream,
             TimeSpan wait,
-            TimeSpan interval)
+            TimeSpan interval
+            )
         {
-            DisposeOnCompletion = disposeOnCompletion;
-            LoggingAction = loggingAction;
-            FailureAction = failureAction;
-            Wait = wait;
-            Interval = interval;
+            ErrorStream = errorStream;
+            LogStream   = logStream;
+            Wait        = wait;
+            Interval    = interval;
         }
 
+        /// <summary>
+        /// Create an IsotopeSettings
+        /// </summary>
         public static IsotopeSettings Create(
-            bool? disposeOnCompletion = null,
-            Action<string, int> loggingAction = null,
-            Action<Error, Log> failureAction = null,
+            Subject<Error> errorStream,
+            Subject<LogOutput> logStream,
             TimeSpan? wait = null,
             TimeSpan? interval = null) =>
             new IsotopeSettings(
-                disposeOnCompletion ?? defaultDisposeOnCompletion,
-                loggingAction ?? defaultLoggingAction,
-                failureAction ?? defaultFailureAction,
+                errorStream,
+                logStream,
                 wait ?? defaultWait,
                 interval ?? defaultInterval);
-
-        static Action<Error, Log> MakeFail(Action<string, Log> f) =>
-            f == null
-                ? defaultFailureAction
-                : (Error err, Log log) => f(err.ToString(), log);
-
-    }
+ 
+        /// <summary>
+        /// Create an IsotopeSettings
+        /// </summary>
+        public static IsotopeSettings Create(
+            TimeSpan? wait = null,
+            TimeSpan? interval = null) =>
+            new IsotopeSettings(
+                new Subject<Error>(),
+                new Subject<LogOutput>(),
+                wait ?? defaultWait,
+                interval ?? defaultInterval);   }
 }

--- a/src/Isotope80/IsotopeState.cs
+++ b/src/Isotope80/IsotopeState.cs
@@ -1,6 +1,8 @@
 ﻿using LanguageExt;
 using OpenQA.Selenium;
 using System;
+using System.Runtime.ExceptionServices;
+using LanguageExt.Common;
 using static LanguageExt.Prelude;
 
 namespace Isotope80
@@ -10,7 +12,7 @@ namespace Isotope80
         internal readonly Option<IWebDriver> Driver;
         internal readonly IsotopeSettings Settings;
         internal readonly Map<string, string> Configuration;
-        public readonly Option<string> Error;
+        public readonly Seq<Error> Error;
         public readonly Log Log;
 
         /// <summary>
@@ -19,7 +21,18 @@ namespace Isotope80
         public static IsotopeState Create(IsotopeSettings settings) =>
             Empty.With(Settings: settings);
 
-        internal IsotopeState With(Option<IWebDriver>? Driver = null, IsotopeSettings Settings = null, Map<string, string>? Configuration = null, Option<string>? Error = null, Log Log = null) => new IsotopeState(Driver ?? this.Driver, Settings ?? this.Settings, Configuration ?? this.Configuration, Error ?? this.Error, Log ?? this.Log);
+        internal IsotopeState With(
+            Option<IWebDriver>? Driver = null,
+            IsotopeSettings Settings = null,
+            Map<string, string>? Configuration = null,
+            Seq<Error>? Error = null,
+            Log Log = null) =>
+            new IsotopeState(
+                Driver ?? this.Driver,
+                Settings ?? this.Settings,
+                Configuration ?? this.Configuration, 
+                Error ?? this.Error, 
+                Log ?? this.Log);
 
         internal static IsotopeState Empty =
             new IsotopeState(default, IsotopeSettings.Create(), default, default, Log.Empty);
@@ -28,7 +41,7 @@ namespace Isotope80
             Option<IWebDriver> driver,
             IsotopeSettings settings,
             Map<string, string> configuration,
-            Option<string> error, 
+            Seq<Error> error, 
             Log log)
         {            
             Driver = driver;
@@ -37,6 +50,18 @@ namespace Isotope80
             Error = error;
             Log = log;
         }
+
+        internal IsotopeState AddError(Error err) =>
+            With(Error: Error.Add(err));
+
+        internal IsotopeState AddError(string err) =>
+            AddError(LanguageExt.Common.Error.New(err));
+
+        internal IsotopeState AddErrors(Seq<Error> err) =>
+            With(Error: Error + err);
+
+        internal IsotopeState AddErrors(Seq<string> err) =>
+            AddErrors(err.Map(LanguageExt.Common.Error.New));
 
         internal IsotopeState Write(string log, Action<string, int> action) =>
             With(Log: Log.Append(log, action));
@@ -50,7 +75,37 @@ namespace Isotope80
         internal Unit DisposeWebDriver() =>
             Driver.Match(
                 Some: d => { d.Quit(); return unit; },
-                None: () => unit);       
+                None: () => unit);
+
+        /// <summary>
+        /// Throw if the state is faulted
+        /// </summary>
+        /// <remarks>
+        /// If there's one error, then its original context is maintained (stack trace, etc)
+        /// </remarks>
+        public Unit IfFailedThrow()
+        {
+            if (Error.IsEmpty)
+            {
+                return unit;
+            }
+            Error.Iter(err => Settings.FailureAction(err, Log));
+            if (Error.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(Error.Head).Throw(); 
+            }
+            else
+            {
+                throw new AggregateException(Error.Map(e => (Exception) e));
+            }
+            return unit;
+        }
+
+        /// <summary>
+        /// True if the state is faulted
+        /// </summary>
+        public bool IsFaulted =>
+            !Error.IsEmpty;
     }
 
     public class IsotopeState<A>
@@ -66,5 +121,16 @@ namespace Isotope80
 
         public IsotopeState<T> Map<T>(Func<A, T> mapper) =>
             new IsotopeState<T>(mapper(Value), State);
+
+        /// <summary>
+        /// True if the state is faulted
+        /// </summary>
+        public bool IsFaulted =>
+            State.IsFaulted;
+
+        internal IsotopeState<B> CastError<B>() =>
+            IsFaulted
+                ? new IsotopeState<B>(default, State)
+                : throw new InvalidOperationException("Only cast when state is faulted");
     }
 }

--- a/src/Isotope80/Isotope_A.cs
+++ b/src/Isotope80/Isotope_A.cs
@@ -47,10 +47,6 @@ namespace Isotope80
         public (IsotopeState state, A value) Run(IsotopeSettings settings = null)
         {
             var res = Invoke(IsotopeState.Empty.With(Settings: settings));
-            if (res.State.Settings.DisposeOnCompletion)
-            {
-                res.State.DisposeWebDriver();
-            }
             return(res.State, res.Value);
         }
 

--- a/src/Isotope80/Isotope_A.cs
+++ b/src/Isotope80/Isotope_A.cs
@@ -1,0 +1,274 @@
+using System;
+using LanguageExt;
+using LanguageExt.Common;
+using OpenQA.Selenium;
+using static LanguageExt.Prelude;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Environment-free isotope computation
+    /// </summary>
+    /// <typeparam name="A">Bound value</typeparam>
+    public struct Isotope<A>
+    {
+        readonly Func<IsotopeState, IsotopeState<A>> Thunk;
+        
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="thunk">Thunk</param>
+        public Isotope(Func<IsotopeState, IsotopeState<A>> thunk) =>
+            Thunk = thunk;
+
+        /// <summary>
+        /// Invoke the computation
+        /// </summary>
+        /// <param name="state">State</param>
+        /// <returns>Result of invoking the isotope computation</returns>
+        internal IsotopeState<A> Invoke(IsotopeState state)
+        {
+            try
+            {
+                return Thunk?.Invoke(state) ?? throw new InvalidOperationException("Isotope computation not initialised");
+            }
+            catch (Exception e)
+            {
+                return new IsotopeState<A>(default, state.AddError(Error.New(e)));
+            }
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public (IsotopeState state, A value) Run(IsotopeSettings settings = null)
+        {
+            var res = Invoke(IsotopeState.Empty.With(Settings: settings));
+            if (res.State.Settings.DisposeOnCompletion)
+            {
+                res.State.DisposeWebDriver();
+            }
+            return(res.State, res.Value);
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public (IsotopeState state, A value) RunAndThrowOnError(IsotopeSettings settings = null)
+        {
+            var (state, value) = Run(settings);
+            state.IfFailedThrow();
+            return (state, value);
+        }
+
+        /// <summary>
+        /// Or operator - evaluates the left hand side, if it fails, it ignores the error and evaluates the right hand side
+        /// </summary>
+        public static Isotope<A> operator |(Isotope<A> lhs, Isotope<A> rhs) => 
+            new Isotope<A>(s =>
+            {
+                var l = lhs.Invoke(s);
+                var r = l.IsFaulted
+                           ? rhs.Invoke(s)
+                           : l;
+
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
+            });
+
+        /// <summary>
+        /// Lift the pure value into the monadic space 
+        /// </summary>
+        public static Isotope<A> Pure(A value) =>
+            new Isotope<A>(s => new IsotopeState<A>(value, s));
+        
+        /// <summary>
+        /// Lift the error into the monadic space 
+        /// </summary>
+        public static Isotope<A> Fail(Error error) =>
+            new Isotope<A>(s => new IsotopeState<A>(default(A), s.AddError(error)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<B> Bind<B>(Func<A, Isotope<B>> f)
+        {
+            var self = this;   
+            return new Isotope<B>(state => 
+            { 
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> Bind<Env, B>(Func<A, Isotope<Env, B>> f)
+        {
+            var self = this;   
+            return new Isotope<Env, B>((env, state) => 
+            { 
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> Bind<B>(Func<A, IsotopeAsync<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<B>(async state => 
+            { 
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<Env, B>(Func<A, IsotopeAsync<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<B> SelectMany<B>(Func<A, Isotope<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> SelectMany<Env, B>(Func<A, Isotope<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> SelectMany<B>(Func<A, IsotopeAsync<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<Env, B>(Func<A, IsotopeAsync<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<C> SelectMany<B, C>(Func<A, Isotope<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, C> SelectMany<Env, B, C>(Func<A, Isotope<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<C> SelectMany<B, C>(Func<A, IsotopeAsync<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<Env, B, C>(Func<A, IsotopeAsync<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public Isotope<B> Map<B>(Func<A, B> f)
+        {
+            var self = this;   
+            return new Isotope<B>(state => 
+            {
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return new IsotopeState<B>(f(s.Value), s.State);
+            });
+        }
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public Isotope<B> Select<B>(Func<A, B> f) =>
+            Map(f);
+
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<A> MapFail(Func<Seq<Error>, Seq<Error>> f)
+        {
+            var self = this;
+            return new Isotope<A>(
+                s => {
+                    var r = self.Invoke(s);
+                    return r.IsFaulted
+                               ? new IsotopeState<A>(default, r.State.With(Error: f(r.State.Error)))
+                               : r;
+                });
+        }
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<B> BiMap<B>(Func<A, B> Succ,  Func<Seq<Error>, Seq<Error>> Fail)
+        {
+            var self = this;
+            return new Isotope<B>(
+                s => {
+                    var r = self.Invoke(s);
+                    return r.IsFaulted
+                               ? new IsotopeState<B>(default, r.State.With(Error: Fail(r.State.Error)))
+                               : new IsotopeState<B>(Succ(r.Value), r.State);
+                });
+        }
+        
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<A> MapFail(Func<Seq<Error>, Error> f) =>
+            MapFail(s => Seq1(f(s)));
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<B> BiMap<B>(Func<A, B> Succ, Func<Seq<Error>, Error> Fail) =>
+            BiMap(Succ, s => Seq1(Fail(s)));
+    }
+}

--- a/src/Isotope80/Isotope_Env_A.cs
+++ b/src/Isotope80/Isotope_Env_A.cs
@@ -50,11 +50,6 @@ namespace Isotope80
         public (IsotopeState state, A value) Run(Env env, IsotopeSettings settings = null)
         {
             var res = Invoke(env, IsotopeState.Empty.With(Settings: settings));
-            if (res.State.Settings.DisposeOnCompletion)
-            {
-                res.State.DisposeWebDriver();
-            }
-
             return (res.State, res.Value);
         }
 

--- a/src/Isotope80/Isotope_Env_A.cs
+++ b/src/Isotope80/Isotope_Env_A.cs
@@ -1,0 +1,284 @@
+using System;
+using LanguageExt;
+using LanguageExt.Common;
+using OpenQA.Selenium;
+using static LanguageExt.Prelude;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Isotope computation with an environment
+    /// </summary>
+    /// <typeparam name="Env">Environment</typeparam>
+    /// <typeparam name="A">Bound value</typeparam>
+    public struct Isotope<Env, A>
+    {
+        readonly Func<Env, IsotopeState, IsotopeState<A>> Thunk;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="thunk">Thunk</param>
+        public Isotope(Func<Env, IsotopeState, IsotopeState<A>> thunk) =>
+            Thunk = thunk;
+
+        /// <summary>
+        /// Invoke the computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="state">State</param>
+        /// <returns>Result of invoking the isotope computation</returns>
+        internal IsotopeState<A> Invoke(Env env, IsotopeState state)
+        {
+            try
+            {
+                return Thunk?.Invoke(env, state) ?? throw new InvalidOperationException("Isotope computation not initialised");
+            }
+            catch (Exception e)
+            {
+                return new IsotopeState<A>(default, state.AddError(Error.New(e)));
+            }
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public (IsotopeState state, A value) Run(Env env, IsotopeSettings settings = null)
+        {
+            var res = Invoke(env, IsotopeState.Empty.With(Settings: settings));
+            if (res.State.Settings.DisposeOnCompletion)
+            {
+                res.State.DisposeWebDriver();
+            }
+
+            return (res.State, res.Value);
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public (IsotopeState state, A value) RunAndThrowOnError(Env env, IsotopeSettings settings = null)
+        {
+            var (state, value) = Run(env, settings);
+            state.IfFailedThrow();
+            return (state, value);
+        }
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator Isotope<Env, A>(Isotope<A> ma) =>
+            new Isotope<Env, A>((_, state) => ma.Invoke(state));
+
+        /// <summary>
+        /// Or operator - evaluates the left hand side, if it fails, it ignores the error and evaluates the right hand side
+        /// </summary>
+        public static Isotope<Env, A> operator |(Isotope<Env, A> lhs, Isotope<Env, A> rhs) =>
+            new Isotope<Env, A>((e, s) => {
+                                    var l = lhs.Invoke(e, s);
+                                    var r = l.IsFaulted
+                                                ? rhs.Invoke(e, s)
+                                                : l;
+
+                                    return r.IsFaulted
+                                               ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                                               : r;
+                                });
+
+        /// <summary>
+        /// Lift the pure value into the monadic space 
+        /// </summary>
+        public static Isotope<Env, A> Pure(A value) =>
+            new Isotope<Env, A>((e, s) => new IsotopeState<A>(value, s));
+
+        /// <summary>
+        /// Lift the error into the monadic space 
+        /// </summary>
+        public static Isotope<Env, A> Fail(Error error) =>
+            new Isotope<Env, A>((e, s) => new IsotopeState<A>(default(A), s.AddError(error)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> Bind<B>(Func<A, Isotope<B>> f)
+        {
+            var self = this;   
+            return new Isotope<Env, B>((env, state) => 
+            { 
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> Bind<B>(Func<A, Isotope<Env, B>> f)
+        {
+            var self = this;   
+            return new Isotope<Env, B>((env, state) => 
+            { 
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, IsotopeAsync<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, IsotopeAsync<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> SelectMany<B>(Func<A, Isotope<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> SelectMany<B>(Func<A, Isotope<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, IsotopeAsync<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, IsotopeAsync<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, C> SelectMany<B, C>(Func<A, Isotope<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, C> SelectMany<B, C>(Func<A, Isotope<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, IsotopeAsync<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, IsotopeAsync<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public Isotope<Env, B> Map<B>(Func<A, B> f)
+        {
+            var self = this;   
+            return new Isotope<Env, B>((env, state) => 
+            {
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return new IsotopeState<B>(f(s.Value), s.State);
+            });
+        }
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public Isotope<Env, B> Select<B>(Func<A, B> f) =>
+            Map(f);
+
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<Env, A> MapFail(Func<Seq<Error>, Seq<Error>> f)
+        {
+            var self = this;
+            return new Isotope<Env, A>(
+                (e, s) => {
+                    var r = self.Invoke(e, s);
+                    return r.IsFaulted
+                               ? new IsotopeState<A>(default, r.State.With(Error: f(r.State.Error)))
+                               : r;
+                });
+        }
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<Env, B> BiMap<B>(Func<A, B> Succ,  Func<Seq<Error>, Seq<Error>> Fail)
+        {
+            var self = this;
+            return new Isotope<Env, B>(
+                (e, s) => {
+                    var r = self.Invoke(e, s);
+                    return r.IsFaulted
+                               ? new IsotopeState<B>(default, r.State.With(Error: Fail(r.State.Error)))
+                               : new IsotopeState<B>(Succ(r.Value), r.State);
+                });
+        }    
+        
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<Env, A> MapFail(Func<Seq<Error>, Error> f) =>
+            MapFail(s => Seq1(f(s)));
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<Env, B> BiMap<B>(Func<A, B> Succ, Func<Seq<Error>, Error> Fail) =>
+            BiMap(Succ, s => Seq1(Fail(s)));
+    }
+}

--- a/src/Isotope80/Log.cs
+++ b/src/Isotope80/Log.cs
@@ -38,7 +38,7 @@ namespace Isotope80
         /// <summary>
         /// Empty log
         /// </summary>
-        public static readonly Log Empty = new Log(-1, default, "", default);
+        public static readonly Log Empty = new Log(0, default, "", default);
         
         /// <summary>
         /// Number of tabs to indent
@@ -65,9 +65,9 @@ namespace Isotope80
         /// </summary>
         internal Log(int indent, LogType type, string message, Seq<Log> children)
         {
-            Indent   = indent;
+            Indent   = indent >= 0 ? indent : throw new ArgumentOutOfRangeException(nameof(indent));
             Type     = type;
-            Message  = message;
+            Message  = message ?? throw new ArgumentNullException(nameof(message));
             Children = children;
         }
 
@@ -131,7 +131,7 @@ namespace Isotope80
     /// <summary>
     /// Log output
     /// </summary>
-    public struct LogOutput
+    public readonly struct LogOutput
     {
         /// <summary>
         /// Log message
@@ -151,8 +151,12 @@ namespace Isotope80
         /// <summary>
         /// Ctor
         /// </summary>
-        public LogOutput(string message, LogType type, int index) =>
-            (Message, Type, Indent) = (message, type, Math.Max(0, index));
+        public LogOutput(string message, LogType type, int indent)
+        {
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            Type    = type;
+            Indent  = indent >= 0 ? indent :  throw new ArgumentOutOfRangeException(nameof(indent));
+        }
 
         /// <summary>
         /// Tabbed format display 

--- a/src/Isotope80/Log.cs
+++ b/src/Isotope80/Log.cs
@@ -4,93 +4,160 @@ using static LanguageExt.Prelude;
 
 namespace Isotope80
 {
-    public class Log
+    /// <summary>
+    /// Log entry type
+    /// </summary>
+    public enum LogType
     {
-        private readonly Seq<Node> Nodes;
-        private readonly Option<Node> Current;
-
-        public Log(Seq<Node> nodes, Option<Node> current)
-        {
-            Nodes = nodes;
-            Current = current;
-        }
-
-        public Log With(Seq<Node>? nodes = null, Option<Node>? current = null) =>
-            new Log(nodes ?? Nodes, current ?? Current);
-
-        public Log Append(string message, Action<string, int> action, int depth = 0) =>
-            Current.Match(
-                Some: x => With(current: x.Append(message, action, depth)),
-                None: () => {
-                    action(message, depth);
-                    return With(nodes: Nodes.Add(Node.New(message)));
-                });
-
-        public Log Push(string message, Action<string, int> action, int depth = 0) =>
-            Current.Match(
-                Some: x => With(current: x.Push(message, action, depth)),
-                None: () => {
-                    action(message, depth);
-                    return With(current: Node.New(message));
-                });
-
-        public Log Pop() =>
-            Current.Match(
-                Some: x => x.Children.Current.IsSome
-                           ? With(current: x.Pop())
-                           : With(nodes: Nodes.Add(x), current: None),
-                None: () => this);
-
-        public static Log Empty => new Log(new Seq<Node>(), None);
-
-        public override string ToString() =>
-            string.Join(Environment.NewLine, ToString(0));
-
-        public Seq<string> ToString(int indent) =>
-            Nodes
-                .Append(Current.ToSeq())
-                .Bind(x => x.ToString(indent));
-
-        public string Trace() =>
-            string.Join(Environment.NewLine, Trace(0));
-
-        public Seq<string> Trace(int indent) =>
-            Nodes.Map(x => new string('\t', indent) + x.Message)
-                 .Append(Current.Bind(x => x.Trace(indent)))
-                 .ToSeq();
+        /// <summary>
+        /// Contextual header
+        /// </summary>
+        Context,
+        
+        /// <summary>
+        /// Information message
+        /// </summary>
+        Info,
+        
+        /// <summary>
+        /// Warning message
+        /// </summary>
+        Warn,
+        
+        /// <summary>
+        /// Error message
+        /// </summary>
+        Error
     }
 
-    public class Node
+    /// <summary>
+    /// Nested log
+    /// </summary>
+    public class Log
     {
-        public readonly string Message;
-        public readonly Log Children;
+        /// <summary>
+        /// Empty log
+        /// </summary>
+        public static readonly Log Empty = new Log(-1, default, "", default);
+        
+        /// <summary>
+        /// Number of tabs to indent
+        /// </summary>
+        public readonly int Indent;
 
-        private Node(string message, Log children)
+        /// <summary>
+        /// Log type
+        /// </summary>
+        public readonly LogType Type;
+        
+        /// <summary>
+        /// Node message
+        /// </summary>
+        public readonly string Message;
+        
+        /// <summary>
+        /// Child messages
+        /// </summary>
+        public readonly Seq<Log> Children;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        internal Log(int indent, LogType type, string message, Seq<Log> children)
         {
-            Message = message;
+            Indent   = indent;
+            Type     = type;
+            Message  = message;
             Children = children;
         }
 
-        public Node With(string message = null, Log children = null) =>
-            new Node(message ?? Message, children ?? Children);
+        /// <summary>
+        /// Add a message to the log
+        /// </summary>
+        /// <param name="ctx">Context</param>
+        public (Log Parent, Log Child) Context(string ctx)
+        {
+            var child = new Log(Indent + 1, LogType.Info, ctx, default);
+            return (new Log(Indent, Type, Message, Children.Add(child)), child);
+        }
 
-        public Node Append(string message, Action<string, int> action, int depth) => 
-            With(children: Children.Append(message, action, depth+1));
+        /// <summary>
+        /// Add a log entry
+        /// </summary>
+        public Log Add(Log log) =>
+            new Log(Indent, Type, Message, Children.Add(log));
 
-        public Node Push(string message, Action<string, int> action, int depth) => 
-            With(children: Children.Push(message, action, depth+1));
+        /// <summary>
+        /// Add a message to the log
+        /// </summary>
+        /// <param name="message">Message to log</param>
+        public Log Info(string message) =>
+            new Log(Indent, Type, Message, Children.Add(new Log(Indent + 1, LogType.Info, $"INFO: {message}", default))); 
 
-        public Node Pop() => With(children: Children.Pop());
+        /// <summary>
+        /// Add a message to the log
+        /// </summary>
+        /// <param name="message">Message to log</param>
+        public Log Warning(string message) =>
+            new Log(Indent, Type, Message, Children.Add(new Log(Indent + 1, LogType.Warn, $"WARN: {message}", default)));
 
-        public static Node New(string message) => new Node(message, Log.Empty);
+        /// <summary>
+        /// Add a message to the log
+        /// </summary>
+        /// <param name="message">Message to log</param>
+        public Log Error(string message) =>
+            new Log(Indent, Type, Message, Children.Add(new Log(Indent + 1, LogType.Error, $"ERRO: {message}", default)));
 
-        public Seq<string> ToString(int indent) =>
-            Seq1(new string('\t', indent) + Message)
-                .Append(Children.ToString(++indent));
+        /// <summary>
+        /// Create a new Node
+        /// </summary>
+        public static Log New(string message) => 
+            new Log(0, LogType.Info, message, default);
 
-        public Seq<string> Trace(int indent) =>
-            Seq1(new string('\t', indent) + Message)
-               .Append(Children.Trace(++indent));
+        /// <summary>
+        /// ToString
+        /// </summary>
+        public override string ToString() =>
+            String.Join(Environment.NewLine, ToSeq());
 
+        /// <summary>
+        /// ToSeq
+        /// </summary>
+        public Seq<string> ToSeq() =>
+            Seq1(new string('\t', Indent) + Message)
+                .Append(Children.Map(c => c.ToSeq()));
+    }
+
+    /// <summary>
+    /// Log output
+    /// </summary>
+    public struct LogOutput
+    {
+        /// <summary>
+        /// Log message
+        /// </summary>
+        public readonly string Message;
+        
+        /// <summary>
+        /// Severity type
+        /// </summary>
+        public readonly LogType Type;
+        
+        /// <summary>
+        /// Indentation
+        /// </summary>
+        public readonly int Indent;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        public LogOutput(string message, LogType type, int index) =>
+            (Message, Type, Indent) = (message, type, Math.Max(0, index));
+
+        /// <summary>
+        /// Tabbed format display 
+        /// </summary>
+        public override string ToString() =>
+            new string('\t', Indent) + Message;
     }
 }

--- a/src/Isotope80/WebDriverSelect.cs
+++ b/src/Isotope80/WebDriverSelect.cs
@@ -1,0 +1,28 @@
+namespace Isotope80
+{
+    /// <summary>
+    /// Web driver selector
+    /// </summary>
+    public enum WebDriverSelect
+    {
+        /// <summary>
+        /// Google Chrome web-browser
+        /// </summary>
+        Chrome,
+
+        /// <summary>
+        /// Microsoft Edge web-browser
+        /// </summary>
+        Edge,
+
+        /// <summary>
+        /// Mozilla Firefox web-browser
+        /// </summary>
+        Firefox,
+       
+        /// <summary>
+        /// Microsoft Internet Explorer web-browser
+        /// </summary>
+        InternetExplorer
+    }
+}


### PR DESCRIPTION
After @appetere 's changes last week, I could see that some of the issues I'd dealt with in lang-ext with `Aff` and `Eff` were going to rear their head here.  Mainly around how to manage `n` types that should work with each other, but have different behaviours.  As the number of those types grows, the lack of any kind of conversion operators means that the overloaded function count grows exponentially.

So, I have come to the conclusion that building a monad [around a raw delegate] is a bad idea.  This is how `Try` and `TryOption` are built in lang-ext, as well as computation types like `Reader`.  It's been a big limitation, and that's why I made the `Aff` and `Eff` monads into `struct` types that wrapped a `Func`.  

> It gives more control over the invocation (for example, enforcing exception handling).  It also allows much more power when it comes to compatibility with other types (via implicit conversions, for example).

**Commit notes**

 - Moved the `Isotope` delegates inside structs, this allows for additional things like implicit conversion and other operators like `|`, but also makes it easier to package up the functionality for the monadic type in its definition, rather than lots of extension methods.  Additionally, it hides the `Func`, which means that it can't be invoked with `ma()`, so it's not possible to side-step things like exception handling.

 - Added two more monadic types: `IsotopeAsync<A>` and `IsotopeAsync<Env, A>`.  Unsurprisingly, these support asynchronous operations.

 - Added a method to the `Isotope` types called `Invoke` (which does the actual running of the computation), it now captures the Exceptions.

 - Changes the `IsotopeState` `Option<string> Error` to `Seq<Error> Error`.  This is because the `Collect` function clearly wanted to be able to aggregate errors.  Also, there's lots of string building of error-messages to try and capture context (like `tryf`, etc).  So, by using a proper `Error` type it deals with this.

 - Updated the set of methods that each Isotope type supports, with variants for all combinations:
     - `Run(settings)`
     - `Run(driver, settings)`
     - `RunAndThrowOnError(settings)`
     - `RunAndThrowOnError(driver, settings)`
     - `operator |`
     - `Pure(A)`
     - `Fail(Error)`
     - `Bind(f)`
     - `SelectMany(f)`
     - `SelectMany(bind, proj)`
     - `Map(f)`
     - `MapFail(f)`
     - `BiMap(Succ, Fail)`
     - `implicit operator` (convert from the other `Isotope` types)

- Added `fail(Error)` and `fail(Exception)` to go with `fail(string)`

- Added the iso functions to make it easy to lift different types of function into the Isotope monadic space:
     - `iso(Func<A>)`
     - `iso(Func<Fin<A>>)`
     - `iso(Func<IsotopeState, A>)`
     - `iso(Func<IsotopeState, Fin<A>>)`
     - `iso(Func<Env, IsotopeState, A>)`
     - `iso(Func<Env, IsotopeState, Fin<A>>)`
     - `isoAsync(Func<ValueTask<A>>)`
     - `isoAsync(Func<ValueTask<Fin<A>>>)`
     - `isoAsync(Func<IsotopeState, ValueTask<A>>)`
     - `isoAsync(Func<IsotopeState, ValueTask<Fin<A>>>)`
     - `isoAsync(Func<Env, IsotopeState, ValueTask<A>>)`
     - `isoAsync(Func<Env, IsotopeState, ValueTask<Fin<A>>>)`

- Updated `trya` and `tryf` to aggregate the errors generated, and then repackage the aggregated errors in a new Error with a label provided as-before.  This maintains the context and stack-frames.

- Added the variants of `Sequence` that were missing

- Removed the `pure` and `fail` variants that used `Env`.  These are not needed when we have implicit conversion operators and the variant SelectMany implementations.  All `pure` and `fail` are environment-less, because they are working with pure values.

- Updated the `Collect` function to collect and aggregate errors correctly.  I left the `Log` sh1tshow alone, but that should be sorted.  The impure logging isn't ideal either.  This should be fixed.  But that's not for now.

- Added the variants of `Collect` for the different `Isotope` types.

- Updated: the various `ToIsotope` functions that were a bit of a mess.  They now work with `Error` and allow for maintenance of the context without the programmer having to do it themselves.  Also, there's now auto conversion between `Try<A>` / Either<Error, R>  and `Isotope<A>`

- Added `IfFailedThrow` to `IsotopeState`, this throws the captured exceptions and restores the stack-frame context.

- Updated to the latest lang-ext so `Fin`<A> could be used.

- Started adding some much needed documentation.

