### PR TITLE
WIP: Removal of direct access to IWebElement + a new composable query system

### DIFF
--- a/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
+++ b/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="LanguageExt.Core" Version="3.5.20-beta" />
     <PackageReference Include="Selenium.Chrome.WebDriver" Version="81.0.0" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
+++ b/samples/Isotope80.Samples.Console/Isotope80.Samples.Console.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LanguageExt.Core" Version="3.3.47" />
+    <PackageReference Include="LanguageExt.Core" Version="3.5.20-beta" />
     <PackageReference Include="Selenium.Chrome.WebDriver" Version="81.0.0" />
   </ItemGroup>
 

--- a/samples/Isotope80.Samples.Console/Meddbase.cs
+++ b/samples/Isotope80.Samples.Console/Meddbase.cs
@@ -16,7 +16,7 @@ namespace Isotope80.Samples.Console
 
         public static Isotope<Unit> WaitThenClick(By selector) =>
             from el in waitUntilClickable(selector)
-            from _2 in click(el)
+            from _2 in click(selector)
             select unit;
 
         public static Isotope<Unit> ClickMoreMenu =>

--- a/samples/Isotope80.Samples.Console/Meddbase.cs
+++ b/samples/Isotope80.Samples.Console/Meddbase.cs
@@ -9,10 +9,10 @@ namespace Isotope80.Samples.Console
     {
         public static Isotope<Unit> GoToDesktopSite =>
             context("Go to Desktop Site",
-                    from _1 in log("Update Window Size")
-                    from _2 in setWindowSize(1280,960)
-                    from _3 in nav("https://www.meddbase.com")
-                    select unit);
+                from _1 in info("Update Window Size")
+                from _2 in setWindowSize(1280,960)
+                from _3 in nav("https://www.meddbase.com")
+                select unit);
 
         public static Isotope<Unit> WaitThenClick(By selector) =>
             from el in waitUntilClickable(selector)

--- a/samples/Isotope80.Samples.Console/Program.cs
+++ b/samples/Isotope80.Samples.Console/Program.cs
@@ -3,6 +3,7 @@ using System;
 using LanguageExt;
 using LanguageExt.Common;
 using static System.Console;
+using static Isotope80.Isotope;
 
 namespace Isotope80.Samples.Console
 {
@@ -13,8 +14,7 @@ namespace Isotope80.Samples.Console
             Action<string, int> consoleLogger =
                 (x, y) => WriteLine(new string('\t', y) + x);
 
-            (var state, var value) = Meddbase.GoToPageAndOpenCareers.Run(
-                new ChromeDriver(), 
+            (var state, var value) = withChromeDriver(Meddbase.GoToPageAndOpenCareers).Run(
                     IsotopeSettings.Create(
                         loggingAction: consoleLogger));
             

--- a/samples/Isotope80.Samples.Console/Program.cs
+++ b/samples/Isotope80.Samples.Console/Program.cs
@@ -2,6 +2,7 @@
 using System;
 using LanguageExt;
 using LanguageExt.Common;
+using static LanguageExt.Prelude;
 using static System.Console;
 using static Isotope80.Isotope;
 
@@ -11,12 +12,9 @@ namespace Isotope80.Samples.Console
     {
         static void Main(string[] args)
         {
-            Action<string, int> consoleLogger =
-                (x, y) => WriteLine(new string('\t', y) + x);
-
-            (var state, var value) = withChromeDriver(Meddbase.GoToPageAndOpenCareers).Run(
-                    IsotopeSettings.Create(
-                        loggingAction: consoleLogger));
+            var stgs = IsotopeSettings.Create();
+            stgs.LogStream.Subscribe(x => WriteLine(x));
+            (var state, var value) = withChromeDriver(Meddbase.GoToPageAndOpenCareers).Run(stgs);
             
             Clear();
             

--- a/samples/Isotope80.Samples.Console/Program.cs
+++ b/samples/Isotope80.Samples.Console/Program.cs
@@ -1,5 +1,7 @@
 ﻿using OpenQA.Selenium.Chrome;
 using System;
+using LanguageExt;
+using LanguageExt.Common;
 using static System.Console;
 
 namespace Isotope80.Samples.Console
@@ -20,15 +22,19 @@ namespace Isotope80.Samples.Console
             
             WriteLine("Current Vacancies:\n");
 
-            state.Error.Match(
-                Some: x => WriteLine($"ERROR: {x}"),
-                None: () => value.Iter(x => WriteLine(x)));
-
+            if (state.Error.IsEmpty)
+            {
+                value.Iter(x => WriteLine(x));
+            }
+            else
+            {
+                WriteLine($"ERROR: {state.Error.Head}");
+            }
+            
             WriteLine("\n\nLogs:\n");
-
             WriteLine(state.Log.ToString());
-
             WriteLine();
         }
+      
     }
 }

--- a/samples/Isotope80.Samples.UnitTests/Careers.cs
+++ b/samples/Isotope80.Samples.UnitTests/Careers.cs
@@ -65,7 +65,7 @@ namespace Isotope80.Samples.UnitTests
             Action<Error, Log> xunitOutput = 
                 (x,y) => output.WriteLine(y.ToString());
 
-            (var state, var value) = iso.RunAndThrowOnError(new ChromeDriver(), settings: IsotopeSettings.Create(failureAction: xunitOutput));
+            (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: IsotopeSettings.Create(failureAction: xunitOutput));
         }
     }
 }

--- a/samples/Isotope80.Samples.UnitTests/Careers.cs
+++ b/samples/Isotope80.Samples.UnitTests/Careers.cs
@@ -23,10 +23,10 @@ namespace Isotope80.Samples.UnitTests
 
         public static Isotope<Unit> GoToDesktopSite =>
             context("Go to Desktop Site",
-                    from _1 in log("Update Window Size")
-                    from _2 in setWindowSize(1280, 960)
-                    from _3 in nav("https://www.meddbase.com")
-                    select unit);
+                from _1 in info("Update Window Size")
+                from _2 in setWindowSize(1280, 960)
+                from _3 in nav("https://www.meddbase.com")
+                select unit);
 
         public static Isotope<Unit> WaitThenClick(By selector) =>
             from el in waitUntilClickable(selector)
@@ -62,10 +62,11 @@ namespace Isotope80.Samples.UnitTests
                       from _2  in assert(url == expected, $"Expected URL to be {expected} but it was {url}")
                       select unit;
            
-            Action<Error, Log> xunitOutput = 
-                (x,y) => output.WriteLine(y.ToString());
-
-            (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: IsotopeSettings.Create(failureAction: xunitOutput));
+            var stgs = IsotopeSettings.Create();
+            stgs.LogStream.Subscribe(x => output.WriteLine(x.ToString()));
+            stgs.ErrorStream.Subscribe(x => output.WriteLine(x.ToString()));
+ 
+            (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: IsotopeSettings.Create());
         }
     }
 }

--- a/samples/Isotope80.Samples.UnitTests/Careers.cs
+++ b/samples/Isotope80.Samples.UnitTests/Careers.cs
@@ -4,6 +4,7 @@ using Xunit;
 using static Isotope80.Isotope;
 using static Isotope80.Assertions;
 using LanguageExt;
+using LanguageExt.Common;
 using static LanguageExt.Prelude;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -61,7 +62,7 @@ namespace Isotope80.Samples.UnitTests
                       from _2  in assert(url == expected, $"Expected URL to be {expected} but it was {url}")
                       select unit;
            
-            Action<string, Log> xunitOutput = 
+            Action<Error, Log> xunitOutput = 
                 (x,y) => output.WriteLine(y.ToString());
 
             (var state, var value) = iso.RunAndThrowOnError(new ChromeDriver(), settings: IsotopeSettings.Create(failureAction: xunitOutput));

--- a/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
+++ b/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
@@ -1,0 +1,67 @@
+using OpenQA.Selenium.Chrome;
+using System;
+using LanguageExt;
+using LanguageExt.Common;
+using Xunit;
+using static LanguageExt.Prelude;
+using static System.Console;
+using static Isotope80.Isotope;
+
+namespace Isotope80.Samples.UnitTests
+{
+    public class LoggingTests
+    {
+        [Fact]
+        public void TestNestedContextualLogs()
+        {
+            Seq<string> expected = Seq(
+                "Test 1",
+                "Info for test 1",
+                "More info for test 1",
+                "\tTest 1.SubTest 1",
+                "\tInfo for test Test 1.SubTest 1",
+                "\tMore info for test Test 1.SubTest 1",
+                "\tTest 1.SubTest 2",
+                "\tInfo for test Test 1.SubTest 2",
+                "\tMore info for test Test 1.SubTest 2");
+            
+            Seq<string> logs = default;
+            
+            var stgs = IsotopeSettings.Create();
+            stgs.LogStream.Subscribe(x => logs = logs.Add(x.ToString()));
+
+            var iso2 = context("Test 1",
+                               from a in info("Info for test 1")
+                               from b in info("More info for test 1")
+                               from c in context("Test 1.SubTest 1",
+                                                 from d in info("Info for test Test 1.SubTest 1")
+                                                 from e in info("More info for test Test 1.SubTest 1")
+                                                 select unit)
+                               from f in context("Test 1.SubTest 2",
+                                                 from g in warn("Info for test Test 1.SubTest 2")
+                                                 from h in warn("More info for test Test 1.SubTest 2")
+                                                 select unit)
+                               select unit);
+                                              
+                                
+            (var state2, var value2) = iso2.Run(stgs);
+
+            Assert.True(logs == expected);
+        }
+        
+        [Fact]
+        public void TestNestedContextualErrors()
+        {
+            var stgs = IsotopeSettings.Create();
+
+            var iso = context("Chrome",
+                           context("Start Page",
+                                context("Patient tile",
+                                     fail<Unit>("element not found"))));
+                                
+            (var state, var value) = iso.Run(stgs);
+
+            Assert.True(state.Error.Head.Message == "element not found (Chrome → Start Page → Patient tile)");
+        }
+    }
+}

--- a/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
+++ b/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
@@ -15,33 +15,36 @@ namespace Isotope80.Samples.UnitTests
         public void TestNestedContextualLogs()
         {
             Seq<string> expected = Seq(
-                "Test 1",
-                "Info for test 1",
-                "More info for test 1",
-                "\tTest 1.SubTest 1",
-                "\tInfo for test Test 1.SubTest 1",
-                "\tMore info for test Test 1.SubTest 1",
-                "\tTest 1.SubTest 2",
-                "\tInfo for test Test 1.SubTest 2",
-                "\tMore info for test Test 1.SubTest 2");
+                "Info log",
+                "\tTest 1",
+                "\tInfo for test 1",
+                "\tMore info for test 1",
+                "\t\tTest 1.SubTest 1",
+                "\t\tInfo for test Test 1.SubTest 1",
+                "\t\tMore info for test Test 1.SubTest 1",
+                "\t\tTest 1.SubTest 2",
+                "\t\tInfo for test Test 1.SubTest 2",
+                "\t\tMore info for test Test 1.SubTest 2");
             
             Seq<string> logs = default;
             
             var stgs = IsotopeSettings.Create();
             stgs.LogStream.Subscribe(x => logs = logs.Add(x.ToString()));
 
-            var iso2 = context("Test 1",
-                               from a in info("Info for test 1")
-                               from b in info("More info for test 1")
-                               from c in context("Test 1.SubTest 1",
-                                                 from d in info("Info for test Test 1.SubTest 1")
-                                                 from e in info("More info for test Test 1.SubTest 1")
-                                                 select unit)
-                               from f in context("Test 1.SubTest 2",
-                                                 from g in warn("Info for test Test 1.SubTest 2")
-                                                 from h in warn("More info for test Test 1.SubTest 2")
-                                                 select unit)
-                               select unit);
+            var iso2 = from _ in info("Info log")
+                       from r in context("Test 1",
+                                         from a in info("Info for test 1")
+                                         from b in info("More info for test 1")
+                                         from c in context("Test 1.SubTest 1",
+                                                           from d in info("Info for test Test 1.SubTest 1")
+                                                           from e in info("More info for test Test 1.SubTest 1")
+                                                           select unit)
+                                         from f in context("Test 1.SubTest 2",
+                                                           from g in warn("Info for test Test 1.SubTest 2")
+                                                           from h in warn("More info for test Test 1.SubTest 2")
+                                                           select unit)
+                                         select unit)
+                       select r;
                                               
                                 
             (var state2, var value2) = iso2.Run(stgs);

--- a/src/Isotope80/Assertions.cs
+++ b/src/Isotope80/Assertions.cs
@@ -6,39 +6,68 @@ using static LanguageExt.Prelude;
 
 namespace Isotope80
 {
+    /// <summary>
+    /// Common assertions
+    /// </summary>
     public static class Assertions
     {
+        /// <summary>
+        /// Assert that fact is True
+        /// </summary>
+        /// <param name="fact">Fact to assert</param>
+        /// <param name="label">Label on failure</param>
         public static Isotope<Unit> assert(Isotope<bool> fact, string label) =>
             from f in fact
             from _ in assert(f, label)
             select unit;
         
+        /// <summary>
+        /// Assert that fact is True
+        /// </summary>
+        /// <param name="fact">Fact to assert</param>
+        /// <param name="label">Label on failure</param>
         public static Isotope<Unit> assert(Func<bool> fact, string label) =>
             assert(fact(), label);
 
+        /// <summary>
+        /// Assert that fact is True
+        /// </summary>
+        /// <param name="fact">Fact to assert</param>
+        /// <param name="label">Label on failure</param>
         public static Isotope<Unit> assert(bool fact, string label) =>
             fact ? pure(unit) : fail<Unit>(label);
 
+        /// <summary>
+        /// Assert that an element has text that matches `expected`
+        /// </summary>
+        /// <param name="cssSelector">CSS selector</param>
+        /// <param name="expected">Label on failure</param>
         public static Isotope<Unit> assertElementHasText(string cssSelector, string expected) =>
-            assertElementHasText(By.CssSelector(cssSelector), expected);
+            assertElementHasText(Query.byCss(cssSelector), expected);
 
-        public static Isotope<Unit> assertElementHasText(By selector, string expected) =>
-            from el in findElement(selector)
-            from re in assertElementHasText(el, expected)
+        /// <summary>
+        /// Assert that an element has text that matches `expected`
+        /// </summary>
+        /// <param name="selector">Element selector</param>
+        /// <param name="expected">Label on failure</param>
+        public static Isotope<Unit> assertElementHasText(Query selector, string expected) =>
+            from el in selector.ToIsotopeHead()
+            from __ in assertElementIsDisplayed(selector)
+            from ht in hasText(selector, expected) 
             select unit;
 
-        public static Isotope<Unit> assertElementHasText(IWebElement el, string expected) =>
-            from _ in assertElementIsDisplayed(el)
-            from re in assert(hasText(el, expected), $@"Expected element ""{el}"" to have text ""{expected}"" but it was ""{el.Text}""")
-            select unit;
-
+        /// <summary>
+        /// Assert element is displayed
+        /// </summary>
+        /// <param name="cssSelector">CSS selector</param>
         public static Isotope<Unit> assertElementIsDisplayed(string cssSelector) =>
-            assertElementIsDisplayed(By.CssSelector(cssSelector));
+            assertElementIsDisplayed(Query.byCss(cssSelector));
 
-        public static Isotope<Unit> assertElementIsDisplayed(By selector) =>
+        /// <summary>
+        /// Assert element is displayed
+        /// </summary>
+        /// <param name="selector">Element selector</param>
+        public static Isotope<Unit> assertElementIsDisplayed(Query selector) =>
             assert(displayed(selector), $@"Expected selector ""{selector}"" to be displayed.");
-
-        public static Isotope<Unit> assertElementIsDisplayed(IWebElement el) =>
-            assert(displayed(el), $@"Expected element ""{el}"" to be displayed.");
     }
 }

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -1246,18 +1246,18 @@ namespace Isotope80
             select unit;
 
         public static Isotope<IWebElement> waitUntilClickable(By selector, TimeSpan timeout) =>
-            from _1 in log($"Waiting until clickable: {selector}")
+            from _1 in info($"Waiting until clickable: {selector}")
             from el in waitUntilElementExists(selector)
             from _2 in waitUntilClickable(el, timeout)
             select el;
 
         public static Isotope<Unit> waitUntilClickable(IWebElement el, TimeSpan timeout) =>
             from _ in waitUntil(
-                        from _1a in log($"Checking clickability " + el.PrettyPrint())
+                        from _1a in info($"Checking clickability " + el.PrettyPrint())
                         from d in displayed(el)
                         from e in enabled(el)
                         from o in obscured(el)
-                        from _2a in log($"Displayed: {d}, Enabled: {e}, Obscured: {o}")
+                        from _2a in info($"Displayed: {d}, Enabled: {e}, Obscured: {o}")
                         select d && e && (!o),
                         x => !x)
             select unit;
@@ -1694,9 +1694,9 @@ namespace Isotope80
             let coords = element.Location
             let x = coords.X + (int)Math.Floor((double)(element.Size.Width / 2))
             let y = coords.Y + (int)Math.Floor((double)(element.Size.Height / 2))
-            from _ in log($"X: {x}, Y: {y}")
+            from _ in info($"X: {x}, Y: {y}")
             from top in pure((IWebElement)jsExec.ExecuteScript($"return document.elementFromPoint({x}, {y});"))
-            from _1  in log($"Target: {element.PrettyPrint()}, Top: {top.PrettyPrint()}")
+            from _1  in info($"Target: {element.PrettyPrint()}, Top: {top.PrettyPrint()}")
             select !element.Equals(top);
 
         /// <summary>

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -110,9 +110,13 @@ namespace Isotope80
             new Isotope<A>(s =>
             {
                 var l = lhs.Invoke(s);
-                return l.IsFaulted
+                var r = l.IsFaulted
                            ? rhs.Invoke(s)
                            : l;
+
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
             });
 
         /// <summary>
@@ -416,9 +420,13 @@ namespace Isotope80
         public static Isotope<Env, A> operator |(Isotope<Env, A> lhs, Isotope<Env, A> rhs) =>
             new Isotope<Env, A>((e, s) => {
                                     var l = lhs.Invoke(e, s);
-                                    return l.IsFaulted
-                                               ? rhs.Invoke(e, s)
-                                               : l;
+                                    var r = l.IsFaulted
+                                                ? rhs.Invoke(e, s)
+                                                : l;
+
+                                    return r.IsFaulted
+                                               ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                                               : r;
                                 });
 
         /// <summary>
@@ -719,9 +727,13 @@ namespace Isotope80
             new IsotopeAsync<A>(async s =>
             {
                 var l = await lhs.Invoke(s);
-                return l.IsFaulted
-                           ? await rhs.Invoke(s)
-                           : l;
+                var r = l.IsFaulted
+                            ? await rhs.Invoke(s)
+                            : l;
+
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
             });
 
         /// <summary>
@@ -1041,9 +1053,13 @@ namespace Isotope80
         public static IsotopeAsync<Env, A> operator |(IsotopeAsync<Env, A> lhs, IsotopeAsync<Env, A> rhs) =>
             new IsotopeAsync<Env, A>(async (e, s) => {
                                          var l = await lhs.Invoke(e, s);
-                                         return l.IsFaulted
-                                                    ? await rhs.Invoke(e, s)
-                                                    : l;
+                                         var r = l.IsFaulted
+                                                     ? await rhs.Invoke(e, s)
+                                                     : l;
+
+                                         return r.IsFaulted
+                                                    ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                                                    : r;
                                      });
 
         /// <summary>

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -10,6 +10,7 @@ using LanguageExt.Common;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Edge;
 using OpenQA.Selenium.Firefox;
+using OpenQA.Selenium.IE;
 using static LanguageExt.Prelude;
 
 namespace Isotope80
@@ -274,6 +275,118 @@ namespace Isotope80
                                                select rs);
 
         /// <summary>
+        /// Run the isotope provided with the web-driver context
+        /// </summary>
+        public static Isotope<Unit> withWebDrivers<A>(Isotope<A> ma, params WebDriverSelect[] webDrivers) =>
+            new Isotope<Unit>(s => {
+                           
+                Seq<Error> errors = Empty;
+                
+                foreach (var webDriver in webDrivers)
+                {
+                    var (d, nm) = webDriver switch
+                            {
+                                WebDriverSelect.Chrome           => (new ChromeDriver() as IWebDriver, "Chrome"),
+                                WebDriverSelect.Firefox          => (new FirefoxDriver(), "Firefox"),
+                                WebDriverSelect.Edge             => (new EdgeDriver(), "Edge"),
+                                WebDriverSelect.InternetExplorer => (new InternetExplorerDriver(), "IE"),
+                                _                                => throw new NotSupportedException($"Web-driver not supported: {webDriver}")
+                            };
+
+                    // Run with the web-driver
+                    var r = withWebDriver(d, ma).Invoke(s);
+
+                    // Collect the errors, prefix them with the name of the browser
+                    errors = errors + r.State.Error.Map(e => Error.New($"[{nm}] {e.Message}", e.Exception.IsSome ? (Exception) e : null));
+                }
+                return new IsotopeState<Unit>(default, s.With(Error: errors));
+            });
+
+        /// <summary>
+        /// Run the isotope provided with the web-driver context
+        /// </summary>
+        public static Isotope<Env, Unit> withWebDrivers<Env, A>(Isotope<Env, A> ma, params WebDriverSelect[] webDrivers) =>
+            new Isotope<Env, Unit>((e, s) => {
+                           
+                Seq<Error> errors = Empty;
+                
+                foreach (var webDriver in webDrivers)
+                {
+                    var (d, nm) = webDriver switch
+                            {
+                                WebDriverSelect.Chrome           => (new ChromeDriver() as IWebDriver, "Chrome"),
+                                WebDriverSelect.Firefox          => (new FirefoxDriver(), "Firefox"),
+                                WebDriverSelect.Edge             => (new EdgeDriver(), "Edge"),
+                                WebDriverSelect.InternetExplorer => (new InternetExplorerDriver(), "IE"),
+                                _                                => throw new NotSupportedException($"Web-driver not supported: {webDriver}")
+                            };
+
+                    // Run with the web-driver
+                    var r = withWebDriver(d, ma).Invoke(e, s);
+
+                    // Collect the errors, prefix them with the name of the browser
+                    errors = errors + r.State.Error.Map(e => Error.New($"[{nm}] {e.Message}", e.Exception.IsSome ? (Exception) e : null));
+                }
+                return new IsotopeState<Unit>(default, s.With(Error: errors));
+            });
+
+        /// <summary>
+        /// Run the isotope provided with the web-driver context
+        /// </summary>
+        public static IsotopeAsync<Unit> withWebDrivers<A>(IsotopeAsync<A> ma, params WebDriverSelect[] webDrivers) =>
+            new IsotopeAsync<Unit>(async s => {
+                           
+                Seq<Error> errors = Empty;
+                
+                foreach (var webDriver in webDrivers)
+                {
+                    var (d, nm) = webDriver switch
+                            {
+                                WebDriverSelect.Chrome           => (new ChromeDriver() as IWebDriver, "Chrome"),
+                                WebDriverSelect.Firefox          => (new FirefoxDriver(), "Firefox"),
+                                WebDriverSelect.Edge             => (new EdgeDriver(), "Edge"),
+                                WebDriverSelect.InternetExplorer => (new InternetExplorerDriver(), "IE"),
+                                _                                => throw new NotSupportedException($"Web-driver not supported: {webDriver}")
+                            };
+
+                    // Run with the web-driver
+                    var r = await withWebDriver(d, ma).Invoke(s).ConfigureAwait(false);
+
+                    // Collect the errors, prefix them with the name of the browser
+                    errors = errors + r.State.Error.Map(e => Error.New($"[{nm}] {e.Message}", e.Exception.IsSome ? (Exception) e : null));
+                }
+                return new IsotopeState<Unit>(default, s.With(Error: errors));
+            });
+
+        /// <summary>
+        /// Run the isotope provided with the web-driver context
+        /// </summary>
+        public static IsotopeAsync<Env, Unit> withWebDrivers<Env, A>(IsotopeAsync<Env, A> ma, params WebDriverSelect[] webDrivers) =>
+            new IsotopeAsync<Env, Unit>(async (e, s) => {
+                           
+                Seq<Error> errors = Empty;
+                
+                foreach (var webDriver in webDrivers)
+                {
+                    var (d, nm) = webDriver switch
+                            {
+                                WebDriverSelect.Chrome           => (new ChromeDriver() as IWebDriver, "Chrome"),
+                                WebDriverSelect.Firefox          => (new FirefoxDriver(), "Firefox"),
+                                WebDriverSelect.Edge             => (new EdgeDriver(), "Edge"),
+                                WebDriverSelect.InternetExplorer => (new InternetExplorerDriver(), "IE"),
+                                _                                => throw new NotSupportedException($"Web-driver not supported: {webDriver}")
+                            };
+
+                    // Run with the web-driver
+                    var r = await withWebDriver(d, ma).Invoke(e, s);
+
+                    // Collect the errors, prefix them with the name of the browser
+                    errors = errors + r.State.Error.Map(e => Error.New($"[{nm}] {e.Message}", e.Exception.IsSome ? (Exception) e : null));
+                }
+                return new IsotopeState<Unit>(default, s.With(Error: errors));
+            });
+        
+        /// <summary>
         /// Run the isotope provided with Chrome web-driver
         /// </summary>
         public static Isotope<A> withChromeDriver<A>(Isotope<A> ma) =>
@@ -290,6 +403,12 @@ namespace Isotope80
         /// </summary>
         public static Isotope<A> withFirefoxDriver<A>(Isotope<A> ma) =>
             withWebDriver(new FirefoxDriver(), ma);
+
+        /// <summary>
+        /// Run the isotope provided with Internet Explorer web-driver
+        /// </summary>
+        public static Isotope<A> withInternetExplorerDriver<A>(Isotope<A> ma) =>
+            withWebDriver(new InternetExplorerDriver(), ma);
 
         /// <summary>
         /// Run the isotope provided with Chrome web-driver
@@ -310,6 +429,12 @@ namespace Isotope80
             withWebDriver(new FirefoxDriver(), ma);
         
         /// <summary>
+        /// Run the isotope provided with Internet Explorer web-driver
+        /// </summary>
+        public static Isotope<Env, A> withInternetExplorerDriver<Env, A>(Isotope<Env, A> ma) =>
+            withWebDriver(new InternetExplorerDriver(), ma);
+
+        /// <summary>
         /// Run the isotope provided with Chrome web-driver
         /// </summary>
         public static IsotopeAsync<A> withChromeDriver<A>(IsotopeAsync<A> ma) =>
@@ -326,6 +451,12 @@ namespace Isotope80
         /// </summary>
         public static IsotopeAsync<A> withFirefoxDriver<A>(IsotopeAsync<A> ma) =>
             withWebDriver(new FirefoxDriver(), ma);
+                
+        /// <summary>
+        /// Run the isotope provided with Internet Explorer web-driver
+        /// </summary>
+        public static IsotopeAsync<A> withInternetExplorerDriver<A>(IsotopeAsync<A> ma) =>
+            withWebDriver(new InternetExplorerDriver(), ma);
         
         /// <summary>
         /// Run the isotope provided with Chrome web-driver
@@ -344,6 +475,12 @@ namespace Isotope80
         /// </summary>
         public static IsotopeAsync<Env, A> withFirefoxDriver<Env, A>(IsotopeAsync<Env, A> ma) =>
             withWebDriver(new FirefoxDriver(), ma);
+                
+        /// <summary>
+        /// Run the isotope provided with Internet Explorer web-driver
+        /// </summary>
+        public static IsotopeAsync<Env, A> withInternetExplorerDriver<Env, A>(IsotopeAsync<Env, A> ma) =>
+            withWebDriver(new InternetExplorerDriver(), ma);
         
         /// <summary>
         /// Set the window size of the browser

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -237,33 +237,41 @@ namespace Isotope80
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static Isotope<A> withWebDriver<A>(IWebDriver driver, Isotope<A> ma) =>
-            use(driver, disposeWebDriver, d => from _ in setWebDriver(driver)  
-                                               from r in ma
-                                               select r);
+            use(driver, disposeWebDriver, d => from od in webDriver
+                                               from _1 in setWebDriver(driver)  
+                                               from rs in ma
+                                               from _2 in setWebDriver(od)  
+                                               select rs);
 
         /// <summary>
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static Isotope<Env, A> withWebDriver<Env, A>(IWebDriver driver, Isotope<Env, A> ma) =>
-            use(driver, disposeWebDriver, d => from _ in setWebDriver(driver)  
-                                               from r in ma
-                                               select r);
+            use(driver, disposeWebDriver, d => from od in webDriver
+                                               from _1 in setWebDriver(driver)  
+                                               from rs in ma
+                                               from _2 in setWebDriver(od)  
+                                               select rs);
 
         /// <summary>
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static IsotopeAsync<A> withWebDriver<A>(IWebDriver driver, IsotopeAsync<A> ma) =>
-            use(driver, disposeWebDriver, d => from _ in setWebDriver(driver)  
-                                               from r in ma
-                                               select r);
+            use(driver, disposeWebDriver, d => from od in webDriver
+                                               from _1 in setWebDriver(driver)  
+                                               from rs in ma
+                                               from _2 in setWebDriver(od)  
+                                               select rs);
 
         /// <summary>
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static IsotopeAsync<Env, A> withWebDriver<Env, A>(IWebDriver driver, IsotopeAsync<Env, A> ma) =>
-            use(driver, disposeWebDriver, d => from _ in setWebDriver(driver)  
-                                               from r in ma
-                                               select r);
+            use(driver, disposeWebDriver, d => from od in webDriver
+                                               from _1 in setWebDriver(driver)  
+                                               from rs in ma
+                                               from _2 in setWebDriver(od)  
+                                               select rs);
 
         /// <summary>
         /// Run the isotope provided with Chrome web-driver

--- a/src/Isotope80/Isotope80.csproj
+++ b/src/Isotope80/Isotope80.csproj
@@ -27,8 +27,8 @@
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-codegen" Version="0.6.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="LanguageExt.CodeGen" Version="3.3.47" />
-    <PackageReference Include="LanguageExt.Core" Version="3.3.47" />
+    <PackageReference Include="LanguageExt.CodeGen" Version="3.5.20-beta" />
+    <PackageReference Include="LanguageExt.Core" Version="3.5.20-beta" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
   </ItemGroup>

--- a/src/Isotope80/Isotope80.csproj
+++ b/src/Isotope80/Isotope80.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="LanguageExt.Core" Version="3.5.20-beta" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Isotope80/IsotopeAsync_A.cs
+++ b/src/Isotope80/IsotopeAsync_A.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using OpenQA.Selenium;
+using static LanguageExt.Prelude;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Asynchronous, environment-free, isotope computation
+    /// </summary>
+    /// <typeparam name="A">Bound value</typeparam>
+    public struct IsotopeAsync<A>
+    {
+        readonly Func<IsotopeState, ValueTask<IsotopeState<A>>> Thunk;
+        
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="thunk">Thunk</param>
+        public IsotopeAsync(Func<IsotopeState, ValueTask<IsotopeState<A>>> thunk) =>
+            Thunk = thunk;
+
+        /// <summary>
+        /// Invoke the computation
+        /// </summary>
+        /// <param name="state">State</param>
+        /// <returns>Result of invoking the isotope computation</returns>
+        internal async ValueTask<IsotopeState<A>> Invoke(IsotopeState state)
+        {
+            try
+            {
+                if (Thunk == null)
+                {
+                    throw new InvalidOperationException("Isotope computation not initialised");
+                }
+                return await Thunk(state).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                return new IsotopeState<A>(default, state.AddError(Error.New(e)));
+            }
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public async ValueTask<(IsotopeState state, A value)> Run(IsotopeSettings settings = null)
+        {
+            var res = await Invoke(IsotopeState.Empty.With(Settings: settings)).ConfigureAwait(false);
+            if (res.State.Settings.DisposeOnCompletion)
+            {
+                res.State.DisposeWebDriver();
+            }
+            return(res.State, res.Value);
+        }
+        
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public async ValueTask<(IsotopeState state, A value)> RunAndThrowOnError(IsotopeSettings settings = null)
+        {
+            var (state, value) = await Run(settings).ConfigureAwait(false);
+            state.IfFailedThrow();
+            return (state, value);
+        }
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator IsotopeAsync<A>(Isotope<A> ma) =>
+            new IsotopeAsync<A>(state => new ValueTask<IsotopeState<A>>(ma.Invoke(state)));
+        
+        /// <summary>
+        /// Or operator - evaluates the left hand side, if it fails, it ignores the error and evaluates the right hand side
+        /// </summary>
+        public static IsotopeAsync<A> operator |(IsotopeAsync<A> lhs, IsotopeAsync<A> rhs) => 
+            new IsotopeAsync<A>(async s =>
+            {
+                var l = await lhs.Invoke(s).ConfigureAwait(false);
+                var r = l.IsFaulted
+                            ? await rhs.Invoke(s).ConfigureAwait(false)
+                            : l;
+
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
+            });
+
+        /// <summary>
+        /// Lift the pure value into the monadic space 
+        /// </summary>
+        public static IsotopeAsync<A> Pure(A value) =>
+            new IsotopeAsync<A>(s => new ValueTask<IsotopeState<A>>(new IsotopeState<A>(value, s)));
+        
+        /// <summary>
+        /// Lift the error into the monadic space 
+        /// </summary>
+        public static IsotopeAsync<A> Fail(Error error) =>
+            new IsotopeAsync<A>(s => new ValueTask<IsotopeState<A>>(new IsotopeState<A>(default(A), s.AddError(error))));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> Bind<B>(Func<A, Isotope<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<B>(async state => 
+            { 
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<Env, B>(Func<A, Isotope<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> Bind<B>(Func<A, IsotopeAsync<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<B>(async state => 
+            { 
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(s.State).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<Env, B>(Func<A, IsotopeAsync<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(env, s.State).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> SelectMany<B>(Func<A, Isotope<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<Env, B>(Func<A, Isotope<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> SelectMany<B>(Func<A, IsotopeAsync<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<Env, B>(Func<A, IsotopeAsync<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<C> SelectMany<B, C>(Func<A, Isotope<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<Env, B, C>(Func<A, Isotope<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<C> SelectMany<B, C>(Func<A, IsotopeAsync<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<Env, B, C>(Func<A, IsotopeAsync<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public IsotopeAsync<B> Map<B>(Func<A, B> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<B>(async state => 
+            {
+                var s = await self.Invoke(state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return new IsotopeState<B>(f(s.Value), s.State);
+            });
+        }
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public IsotopeAsync<B> Select<B>(Func<A, B> f) =>
+            Map(f);        
+    
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<A> MapFail(Func<Seq<Error>, Seq<Error>> f)
+        {
+            var self = this;
+            return new IsotopeAsync<A>(
+                async s => {
+                    var r = await self.Invoke(s).ConfigureAwait(false);
+                    return r.IsFaulted
+                               ? new IsotopeState<A>(default, r.State.With(Error: f(r.State.Error)))
+                               : r;
+                });
+        }
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<B> BiMap<B>(Func<A, B> Succ,  Func<Seq<Error>, Seq<Error>> Fail)
+        {
+            var self = this;
+            return new IsotopeAsync<B>(
+                async s => {
+                    var r = await self.Invoke(s).ConfigureAwait(false);
+                    return r.IsFaulted
+                               ? new IsotopeState<B>(default, r.State.With(Error: Fail(r.State.Error)))
+                               : new IsotopeState<B>(Succ(r.Value), r.State);
+                });
+        }
+        
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<A> MapFail(Func<Seq<Error>, Error> f) =>
+            MapFail(s => Seq1(f(s)));
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<B> BiMap<B>(Func<A, B> Succ, Func<Seq<Error>, Error> Fail) =>
+            BiMap(Succ, s => Seq1(Fail(s)));
+    }
+}

--- a/src/Isotope80/IsotopeAsync_A.cs
+++ b/src/Isotope80/IsotopeAsync_A.cs
@@ -52,10 +52,6 @@ namespace Isotope80
         public async ValueTask<(IsotopeState state, A value)> Run(IsotopeSettings settings = null)
         {
             var res = await Invoke(IsotopeState.Empty.With(Settings: settings)).ConfigureAwait(false);
-            if (res.State.Settings.DisposeOnCompletion)
-            {
-                res.State.DisposeWebDriver();
-            }
             return(res.State, res.Value);
         }
         

--- a/src/Isotope80/IsotopeAsync_Env_A.cs
+++ b/src/Isotope80/IsotopeAsync_Env_A.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using OpenQA.Selenium;
+using static LanguageExt.Prelude;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Asynchronous isotope computation with an environment
+    /// </summary>
+    /// <typeparam name="Env">Environment</typeparam>
+    /// <typeparam name="A">Bound value</typeparam>
+    public struct IsotopeAsync<Env, A>
+    {
+        readonly Func<Env, IsotopeState, ValueTask<IsotopeState<A>>> Thunk;
+        
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="thunk">Thunk</param>
+        public IsotopeAsync(Func<Env, IsotopeState, ValueTask<IsotopeState<A>>> thunk) =>
+            Thunk = thunk;
+
+        /// <summary>
+        /// Invoke the computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="state">State</param>
+        /// <returns>Result of invoking the isotope computation</returns>
+        internal async ValueTask<IsotopeState<A>> Invoke(Env env, IsotopeState state)
+        {
+            try
+            {
+                if (Thunk == null)
+                {
+                    throw new InvalidOperationException("Isotope computation not initialised");
+                }
+                return await Thunk(env, state).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                return new IsotopeState<A>(default, state.AddError(Error.New(e)));
+            }
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public async ValueTask<(IsotopeState state, A value)> Run(Env env, IsotopeSettings settings = null)
+        {
+            var res = await Invoke(env, IsotopeState.Empty.With(Settings: settings)).ConfigureAwait(false);
+            if (res.State.Settings.DisposeOnCompletion)
+            {
+                res.State.DisposeWebDriver();
+            }
+
+            return (res.State, res.Value);
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public async ValueTask<(IsotopeState state, A value)> RunAndThrowOnError(Env env, IsotopeSettings settings = null)
+        {
+            var (state, value) = await Run(env, settings).ConfigureAwait(false);
+            state.IfFailedThrow();
+            return (state, value);
+        }
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator IsotopeAsync<Env, A>(Isotope<A> ma) =>
+            new IsotopeAsync<Env, A>((_, state) => new ValueTask<IsotopeState<A>>(ma.Invoke(state)));
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator IsotopeAsync<Env, A>(Isotope<Env, A> ma) =>
+            new IsotopeAsync<Env, A>((env, state) => new ValueTask<IsotopeState<A>>(ma.Invoke(env, state)));
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator IsotopeAsync<Env, A>(IsotopeAsync<A> ma) =>
+            new IsotopeAsync<Env, A>((_, state) => ma.Invoke(state));
+
+        /// <summary>
+        /// Or operator - evaluates the left hand side, if it fails, it ignores the error and evaluates the right hand side
+        /// </summary>
+        public static IsotopeAsync<Env, A> operator |(IsotopeAsync<Env, A> lhs, IsotopeAsync<Env, A> rhs) =>
+            new IsotopeAsync<Env, A>(async (e, s) => {
+                                         var l = await lhs.Invoke(e, s).ConfigureAwait(false);
+                                         var r = l.IsFaulted
+                                                     ? await rhs.Invoke(e, s).ConfigureAwait(false)
+                                                     : l;
+
+                                         return r.IsFaulted
+                                                    ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                                                    : r;
+                                     });
+
+        /// <summary>
+        /// Lift the pure value into the monadic space 
+        /// </summary>
+        public static IsotopeAsync<Env, A> Pure(A value) =>
+            new IsotopeAsync<Env, A>((e, s) => new ValueTask<IsotopeState<A>>(new IsotopeState<A>(value, s)));
+
+        /// <summary>
+        /// Lift the error into the monadic space 
+        /// </summary>
+        public static IsotopeAsync<Env, A> Fail(Error error) =>
+            new IsotopeAsync<Env, A>((e, s) => new ValueTask<IsotopeState<A>>(new IsotopeState<A>(default(A), s.AddError(error))));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, Isotope<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>( async (env, state) => 
+            { 
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, Isotope<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>( async (env, state) => 
+            { 
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, IsotopeAsync<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(s.State).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, IsotopeAsync<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(env, s.State).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, Isotope<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, Isotope<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, IsotopeAsync<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, IsotopeAsync<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, Isotope<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, Isotope<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, IsotopeAsync<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, IsotopeAsync<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public IsotopeAsync<Env, B> Map<B>(Func<A, B> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>( async (env, state) => 
+            {
+                var s = await self.Invoke(env, state).ConfigureAwait(false);
+                if (s.IsFaulted) return s.CastError<B>();
+                return new IsotopeState<B>(f(s.Value), s.State);
+            });
+        }
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public IsotopeAsync<Env, B> Select<B>(Func<A, B> f) =>
+            Map(f);
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<Env, A> MapFail(Func<Seq<Error>, Seq<Error>> f)
+        {
+            var self = this;
+            return new IsotopeAsync<Env, A>(
+                async (e, s) => {
+                    var r = await self.Invoke(e, s).ConfigureAwait(false);
+                    return r.IsFaulted
+                               ? new IsotopeState<A>(default, r.State.With(Error: f(r.State.Error)))
+                               : r;
+                });
+        }
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<Env, B> BiMap<B>(Func<A, B> Succ,  Func<Seq<Error>, Seq<Error>> Fail)
+        {
+            var self = this;
+            return new IsotopeAsync<Env, B>(
+                async (e, s) => {
+                    var r = await self.Invoke(e, s).ConfigureAwait(false);
+                    return r.IsFaulted
+                               ? new IsotopeState<B>(default, r.State.With(Error: Fail(r.State.Error)))
+                               : new IsotopeState<B>(Succ(r.Value), r.State);
+                });
+        }
+        
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<Env, A> MapFail(Func<Seq<Error>, Error> f) =>
+            MapFail(s => Seq1(f(s)));
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public IsotopeAsync<Env, B> BiMap<B>(Func<A, B> Succ, Func<Seq<Error>, Error> Fail) =>
+            BiMap(Succ, s => Seq1(Fail(s)));
+    }
+}

--- a/src/Isotope80/IsotopeAsync_Env_A.cs
+++ b/src/Isotope80/IsotopeAsync_Env_A.cs
@@ -55,11 +55,6 @@ namespace Isotope80
         public async ValueTask<(IsotopeState state, A value)> Run(Env env, IsotopeSettings settings = null)
         {
             var res = await Invoke(env, IsotopeState.Empty.With(Settings: settings)).ConfigureAwait(false);
-            if (res.State.Settings.DisposeOnCompletion)
-            {
-                res.State.DisposeWebDriver();
-            }
-
             return (res.State, res.Value);
         }
 

--- a/src/Isotope80/IsotopeInternal.cs
+++ b/src/Isotope80/IsotopeInternal.cs
@@ -1,0 +1,232 @@
+using LanguageExt;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Threading;
+using System.Threading.Tasks;
+using LanguageExt.Common;
+using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Edge;
+using OpenQA.Selenium.Firefox;
+using OpenQA.Selenium.IE;
+using static LanguageExt.Prelude;
+using static Isotope80.Isotope;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Isotope operations that are working more directly with Selenium, and therefore 
+    /// should never see the light of day.
+    /// </summary>
+    internal static class IsotopeInternal
+    {
+        /// <summary>
+        /// Convert an IWebElement to a SelectElement
+        /// </summary>  
+        public static Isotope<SelectElement> toSelectElement(IWebElement element) =>
+            tryf(() => new SelectElement(element), x => "Problem creating select element: " + x.Message);
+        
+
+        /// <summary>
+        /// Select a &lt;select&gt; option by text
+        /// </summary>        
+        public static Isotope<Unit> selectByText(SelectElement select, string text) =>
+            trya(() => select.SelectByText(text), x => "Unable to select" + x.Message);
+ 
+        /// <summary>
+        /// Select a &lt;select&gt; option by value
+        /// </summary>        
+        public static Isotope<Unit> selectByValue(SelectElement select, string value) =>
+            trya(() => select.SelectByValue(value), x => "Unable to select" + x.Message);
+
+        /// <summary>
+        /// Retrieves the selected option element in a Select Element
+        /// </summary>
+        /// <param name="sel">Web Driver Select Element</param>
+        /// <returns>The selected Option Web Element</returns>
+        public static Isotope<IWebElement> getSelectedOption(SelectElement sel) =>
+            tryf(() => sel.SelectedOption, x => "Unable to get selected option" + x.Message);
+
+        /// <summary>
+        /// Set checkbox value for existing element
+        /// </summary>
+        /// <param name="el">Web Driver Element</param>
+        /// <param name="ticked">Check the box or not</param>
+        /// <returns>Unit</returns>
+        public static Isotope<Unit> setCheckbox(IWebElement el, bool ticked) =>
+            from val in isCheckboxChecked(el)
+            from _   in val == ticked
+                            ? pure(unit)
+                            : click(el)
+            select unit;
+
+        /// <summary>
+        /// Identifies whether an existing checkbox is checked
+        /// </summary>
+        /// <param name="el">Web Driver Element</param>
+        /// <returns>Is checked\s</returns>
+        public static Isotope<bool> isCheckboxChecked(IWebElement el) =>
+            pure(el.Selected);
+
+        /// <summary>
+        /// Gets the text inside an element
+        /// </summary>
+        /// <param name="element">Element containing txt</param>
+        public static Isotope<string> text(IWebElement element) =>
+            tryf(() => element.Text, $@"Error getting text from element: {prettyPrint(element)}");
+
+        /// <summary>
+        /// Gets the value attribute of an element
+        /// </summary>
+        /// <param name="element">Element containing value</param>
+        public static Isotope<string> value(IWebElement element) =>
+            tryf(() => element.GetAttribute("Value"), $@"Error getting value from element: {prettyPrint(element)}");
+
+        /// <summary>
+        /// Looks for a particular style attribute on an existing element
+        /// </summary>
+        /// <param name="el">Web Driver Element</param>
+        /// <param name="style">Style attribute to look up</param>
+        /// <returns>A string representing the style value</returns>
+        public static Isotope<string> getStyle(IWebElement el, string style) =>
+            tryf(() => el.GetCssValue(style), $"Could not find style {style}");
+
+        /// <summary>
+        /// Gets the Z Index style attribute value for an existing element
+        /// </summary>
+        /// <param name="el">Web Driver Element</param>
+        /// <returns>The Z Index value</returns>
+        public static Isotope<int> getZIndex(IWebElement el) =>
+            from zis in getStyle(el, "zIndex")
+            from zii in parseInt(zis).ToIsotope($"z-Index was not valid integer: {zis}.")
+            select zii;
+
+        /// <summary>
+        /// Looks for a particular style attribute on an existing element
+        /// </summary>
+        /// <param name="el">Web element</param>
+        /// <param name="att">Attribute to look up</param>
+        /// <returns>A string representing the attribute value</returns>
+        public static Isotope<string> attribute(IWebElement el, string att) =>
+            tryf(() => el.GetAttribute(att), $"Attribute {att} could not be found.");
+
+        /// <summary>
+        /// Simulates keyboard by sending `keys` 
+        /// </summary>
+        /// <param name="element">Element to type into</param>
+        /// <param name="keys">String of characters that are typed</param>
+        public static Isotope<Unit> sendKeys(IWebElement element, string keys) =>
+            trya(() => element.SendKeys(keys), $@"Error sending keys ""{keys}"" to element: {prettyPrint(element)}");
+
+        /// <summary>
+        /// Simulates the mouse-click
+        /// </summary>
+        /// <param name="element">Element to click</param>
+        public static Isotope<Unit> click(IWebElement element) =>
+            trya(element.Click, $@"Error clicking element: {prettyPrint(element)}");
+
+        /// <summary>
+        /// Clears the content of an element
+        /// </summary>
+        /// <param name="element">Web Driver Element</param>
+        /// <returns>Unit</returns>
+        public static Isotope<Unit> clear(IWebElement element) =>
+            trya(element.Clear, $@"Error clearing element: {prettyPrint(element)}");
+
+        /// <summary>
+        /// Wait for an element to be rendered and clickable, fail if exceeds default timeout
+        /// </summary>
+        public static Isotope<Unit> waitUntilClickable(IWebElement element) =>
+            from w in defaultWait
+            from _ in waitUntilClickable(element, w)
+            select unit;
+
+        public static Isotope<Unit> waitUntilClickable(IWebElement el, TimeSpan timeout) =>
+            from _ in Isotope.waitUntil(
+                from _1a in info($"Checking clickability " + prettyPrint(el))
+                from d in displayed(el)
+                from e in enabled(el)
+                from o in obscured(el)
+                from _2a in info($"Displayed: {d}, Enabled: {e}, Obscured: {o}")
+                select d && e && (!o),
+                x => !x)
+            select unit;
+        
+        public static string prettyPrint(IWebElement x)
+        {
+            var tag = x.TagName;
+            var css = x.GetAttribute("class");
+            var id  = x.GetAttribute("id");
+
+            return $"<{tag} class='{css}' id='{id}'>";
+        }
+
+        /// <summary>
+        /// Checks if an element is currently displayed
+        /// </summary>
+        /// <param name="el">Web element</param>
+        /// <returns>True if the element is currently displayed</returns>
+        public static Isotope<bool> displayed(IWebElement el) =>
+            tryf(() => el.Displayed, $"Error getting display status of {el}");
+
+        /// <summary>
+        /// Checks if an element is currently enabled
+        /// </summary>
+        /// <param name="el">Web element</param>
+        /// <returns>True if the element is currently enabled</returns>
+        public static Isotope<bool> enabled(IWebElement el) =>
+            tryf(() => el.Enabled, $"Error getting enabled status of {el}");
+
+        /// <summary>
+        /// Checks whether the centre point of an element is the foremost element at that position on the page.
+        /// (Uses the JavaScript document.elementFromPoint function)
+        /// </summary>
+        /// <param name="element">Target element</param>
+        /// <returns>true if the element is foremost</returns>
+        public static Isotope<bool> obscured(IWebElement element) =>
+            from dvr in webDriver
+            let jsExec = (IJavaScriptExecutor)dvr
+            let coords = element.Location
+            let x = coords.X + (int)Math.Floor((double)(element.Size.Width >> 1))
+            let y = coords.Y + (int)Math.Floor((double)(element.Size.Height >> 1))
+            from _ in info($"X: {x}, Y: {y}")
+            from top in pure((IWebElement)jsExec.ExecuteScript($"return document.elementFromPoint({x}, {y});"))
+            from _1  in info($"Target: {prettyPrint(element)}, Top: {prettyPrint(top)}")
+            select !element.Equals(top);
+
+        /// <summary>
+        /// Repeatedly runs an Isotope function and checks whether the condition is met 
+        /// </summary>        
+        public static Isotope<A> waitUntil<A>(Isotope<A> iso,
+            Func<A, bool> continueCondition,
+            TimeSpan interval,
+            TimeSpan wait,
+            DateTime started)
+        {
+            return go().Bind(o => o.Match(Some: pure, None: fail<A>("Timed out"))); 
+
+            // NOTE: This will probably have to stop being recursive 
+            Isotope<Option<A>> go() =>
+                DateTime.UtcNow - started >= wait
+                    ? pure<Option<A>>(None)
+                    : (from x in iso
+                       from r in continueCondition(x)
+                                     ? pure(x)
+                                     : fail<A>("Condition failed")
+                       select Some(r)) |
+                      (from _ in pause(interval)
+                       from r in go()
+                       select r);
+        }
+
+        public static Exception Aggregate(Seq<Error> errs) =>
+            errs.IsEmpty
+                ? null
+                : errs.Count == 1
+                    ? (Exception) errs.Head
+                    : new AggregateException(errs.Map(e => (Exception) e));
+    }
+}

--- a/src/Isotope80/IsotopeSettings.cs
+++ b/src/Isotope80/IsotopeSettings.cs
@@ -1,5 +1,6 @@
 ﻿using LanguageExt;
 using System;
+using LanguageExt.Common;
 
 namespace Isotope80
 {
@@ -10,8 +11,8 @@ namespace Isotope80
         private const bool defaultDisposeOnCompletion = true;
         public readonly Action<string, int> LoggingAction;
         private static Action<string, int> defaultLoggingAction = (x,y) => { };
-        public readonly Action<string, Log> FailureAction;
-        private static Action<string, Log> defaultFailureAction = (x, y) => { };
+        public readonly Action<Error, Log> FailureAction;
+        private static Action<Error, Log> defaultFailureAction = (x, y) => { };
         public readonly TimeSpan Wait;
         private static TimeSpan defaultWait = TimeSpan.FromSeconds(10);
         public readonly TimeSpan Interval;
@@ -20,7 +21,7 @@ namespace Isotope80
         private IsotopeSettings(
             bool disposeOnCompletion,
             Action<string, int> loggingAction,
-            Action<string, Log> failureAction,
+            Action<Error, Log> failureAction,
             TimeSpan wait,
             TimeSpan interval)
         {
@@ -34,7 +35,7 @@ namespace Isotope80
         public static IsotopeSettings Create(
             bool? disposeOnCompletion = null,
             Action<string, int> loggingAction = null,
-            Action<string, Log> failureAction = null,
+            Action<Error, Log> failureAction = null,
             TimeSpan? wait = null,
             TimeSpan? interval = null) =>
             new IsotopeSettings(
@@ -43,5 +44,11 @@ namespace Isotope80
                 failureAction ?? defaultFailureAction,
                 wait ?? defaultWait,
                 interval ?? defaultInterval);
+
+        static Action<Error, Log> MakeFail(Action<string, Log> f) =>
+            f == null
+                ? defaultFailureAction
+                : (Error err, Log log) => f(err.ToString(), log);
+
     }
 }

--- a/src/Isotope80/IsotopeSettings.cs
+++ b/src/Isotope80/IsotopeSettings.cs
@@ -1,54 +1,85 @@
 ﻿using LanguageExt;
 using System;
+using System.Reactive.Subjects;
 using LanguageExt.Common;
 
 namespace Isotope80
 {
+    /// <summary>
+    /// Common settings environment that is threaded through every Isotope computation
+    /// </summary>
     [With]
     public partial class IsotopeSettings
     {
-        public readonly bool DisposeOnCompletion;
-        private const bool defaultDisposeOnCompletion = true;
-        public readonly Action<string, int> LoggingAction;
-        private static Action<string, int> defaultLoggingAction = (x,y) => { };
-        public readonly Action<Error, Log> FailureAction;
-        private static Action<Error, Log> defaultFailureAction = (x, y) => { };
-        public readonly TimeSpan Wait;
+        /// <summary>
+        /// Default wait time
+        /// </summary>
         private static TimeSpan defaultWait = TimeSpan.FromSeconds(10);
-        public readonly TimeSpan Interval;
-        private static TimeSpan defaultInterval = TimeSpan.FromMilliseconds(500);
 
+        /// <summary>
+        /// Default interval
+        /// </summary>
+        private static TimeSpan defaultInterval = TimeSpan.FromMilliseconds(500);
+ 
+        /// <summary>
+        /// Errors
+        /// </summary>
+        public readonly Subject<Error> ErrorStream; 
+
+        /// <summary>
+        /// Errors
+        /// </summary>
+        public readonly Subject<LogOutput> LogStream;
+
+        /// <summary>
+        /// Wait time
+        /// </summary>
+        public readonly TimeSpan Wait;
+        
+        /// <summary>
+        /// Interval time
+        /// </summary>
+        public readonly TimeSpan Interval;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
         private IsotopeSettings(
-            bool disposeOnCompletion,
-            Action<string, int> loggingAction,
-            Action<Error, Log> failureAction,
+            Subject<Error> errorStream,
+            Subject<LogOutput> logStream,
             TimeSpan wait,
-            TimeSpan interval)
+            TimeSpan interval
+            )
         {
-            DisposeOnCompletion = disposeOnCompletion;
-            LoggingAction = loggingAction;
-            FailureAction = failureAction;
-            Wait = wait;
-            Interval = interval;
+            ErrorStream = errorStream;
+            LogStream   = logStream;
+            Wait        = wait;
+            Interval    = interval;
         }
 
+        /// <summary>
+        /// Create an IsotopeSettings
+        /// </summary>
         public static IsotopeSettings Create(
-            bool? disposeOnCompletion = null,
-            Action<string, int> loggingAction = null,
-            Action<Error, Log> failureAction = null,
+            Subject<Error> errorStream,
+            Subject<LogOutput> logStream,
             TimeSpan? wait = null,
             TimeSpan? interval = null) =>
             new IsotopeSettings(
-                disposeOnCompletion ?? defaultDisposeOnCompletion,
-                loggingAction ?? defaultLoggingAction,
-                failureAction ?? defaultFailureAction,
+                errorStream,
+                logStream,
                 wait ?? defaultWait,
                 interval ?? defaultInterval);
-
-        static Action<Error, Log> MakeFail(Action<string, Log> f) =>
-            f == null
-                ? defaultFailureAction
-                : (Error err, Log log) => f(err.ToString(), log);
-
-    }
+ 
+        /// <summary>
+        /// Create an IsotopeSettings
+        /// </summary>
+        public static IsotopeSettings Create(
+            TimeSpan? wait = null,
+            TimeSpan? interval = null) =>
+            new IsotopeSettings(
+                new Subject<Error>(),
+                new Subject<LogOutput>(),
+                wait ?? defaultWait,
+                interval ?? defaultInterval);   }
 }

--- a/src/Isotope80/IsotopeState.cs
+++ b/src/Isotope80/IsotopeState.cs
@@ -1,6 +1,8 @@
 ﻿using LanguageExt;
 using OpenQA.Selenium;
 using System;
+using System.Runtime.ExceptionServices;
+using LanguageExt.Common;
 using static LanguageExt.Prelude;
 
 namespace Isotope80
@@ -10,7 +12,7 @@ namespace Isotope80
         internal readonly Option<IWebDriver> Driver;
         internal readonly IsotopeSettings Settings;
         internal readonly Map<string, string> Configuration;
-        public readonly Option<string> Error;
+        public readonly Seq<Error> Error;
         public readonly Log Log;
 
         /// <summary>
@@ -19,7 +21,18 @@ namespace Isotope80
         public static IsotopeState Create(IsotopeSettings settings) =>
             Empty.With(Settings: settings);
 
-        internal IsotopeState With(Option<IWebDriver>? Driver = null, IsotopeSettings Settings = null, Map<string, string>? Configuration = null, Option<string>? Error = null, Log Log = null) => new IsotopeState(Driver ?? this.Driver, Settings ?? this.Settings, Configuration ?? this.Configuration, Error ?? this.Error, Log ?? this.Log);
+        internal IsotopeState With(
+            Option<IWebDriver>? Driver = null,
+            IsotopeSettings Settings = null,
+            Map<string, string>? Configuration = null,
+            Seq<Error>? Error = null,
+            Log Log = null) =>
+            new IsotopeState(
+                Driver ?? this.Driver,
+                Settings ?? this.Settings,
+                Configuration ?? this.Configuration, 
+                Error ?? this.Error, 
+                Log ?? this.Log);
 
         internal static IsotopeState Empty =
             new IsotopeState(default, IsotopeSettings.Create(), default, default, Log.Empty);
@@ -28,7 +41,7 @@ namespace Isotope80
             Option<IWebDriver> driver,
             IsotopeSettings settings,
             Map<string, string> configuration,
-            Option<string> error, 
+            Seq<Error> error, 
             Log log)
         {            
             Driver = driver;
@@ -37,6 +50,18 @@ namespace Isotope80
             Error = error;
             Log = log;
         }
+
+        internal IsotopeState AddError(Error err) =>
+            With(Error: Error.Add(err));
+
+        internal IsotopeState AddError(string err) =>
+            AddError(LanguageExt.Common.Error.New(err));
+
+        internal IsotopeState AddErrors(Seq<Error> err) =>
+            With(Error: Error + err);
+
+        internal IsotopeState AddErrors(Seq<string> err) =>
+            AddErrors(err.Map(LanguageExt.Common.Error.New));
 
         internal IsotopeState Write(string log, Action<string, int> action) =>
             With(Log: Log.Append(log, action));
@@ -50,7 +75,37 @@ namespace Isotope80
         internal Unit DisposeWebDriver() =>
             Driver.Match(
                 Some: d => { d.Quit(); return unit; },
-                None: () => unit);       
+                None: () => unit);
+
+        /// <summary>
+        /// Throw if the state is faulted
+        /// </summary>
+        /// <remarks>
+        /// If there's one error, then its original context is maintained (stack trace, etc)
+        /// </remarks>
+        public Unit IfFailedThrow()
+        {
+            if (Error.IsEmpty)
+            {
+                return unit;
+            }
+            Error.Iter(err => Settings.FailureAction(err, Log));
+            if (Error.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(Error.Head).Throw(); 
+            }
+            else
+            {
+                throw new AggregateException(Error.Map(e => (Exception) e));
+            }
+            return unit;
+        }
+
+        /// <summary>
+        /// True if the state is faulted
+        /// </summary>
+        public bool IsFaulted =>
+            !Error.IsEmpty;
     }
 
     public class IsotopeState<A>
@@ -66,5 +121,16 @@ namespace Isotope80
 
         public IsotopeState<T> Map<T>(Func<A, T> mapper) =>
             new IsotopeState<T>(mapper(Value), State);
+
+        /// <summary>
+        /// True if the state is faulted
+        /// </summary>
+        public bool IsFaulted =>
+            State.IsFaulted;
+
+        internal IsotopeState<B> CastError<B>() =>
+            IsFaulted
+                ? new IsotopeState<B>(default, State)
+                : throw new InvalidOperationException("Only cast when state is faulted");
     }
 }

--- a/src/Isotope80/Isotope_A.cs
+++ b/src/Isotope80/Isotope_A.cs
@@ -47,10 +47,6 @@ namespace Isotope80
         public (IsotopeState state, A value) Run(IsotopeSettings settings = null)
         {
             var res = Invoke(IsotopeState.Empty.With(Settings: settings));
-            if (res.State.Settings.DisposeOnCompletion)
-            {
-                res.State.DisposeWebDriver();
-            }
             return(res.State, res.Value);
         }
 

--- a/src/Isotope80/Isotope_A.cs
+++ b/src/Isotope80/Isotope_A.cs
@@ -1,0 +1,274 @@
+using System;
+using LanguageExt;
+using LanguageExt.Common;
+using OpenQA.Selenium;
+using static LanguageExt.Prelude;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Environment-free isotope computation
+    /// </summary>
+    /// <typeparam name="A">Bound value</typeparam>
+    public struct Isotope<A>
+    {
+        readonly Func<IsotopeState, IsotopeState<A>> Thunk;
+        
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="thunk">Thunk</param>
+        public Isotope(Func<IsotopeState, IsotopeState<A>> thunk) =>
+            Thunk = thunk;
+
+        /// <summary>
+        /// Invoke the computation
+        /// </summary>
+        /// <param name="state">State</param>
+        /// <returns>Result of invoking the isotope computation</returns>
+        internal IsotopeState<A> Invoke(IsotopeState state)
+        {
+            try
+            {
+                return Thunk?.Invoke(state) ?? throw new InvalidOperationException("Isotope computation not initialised");
+            }
+            catch (Exception e)
+            {
+                return new IsotopeState<A>(default, state.AddError(Error.New(e)));
+            }
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public (IsotopeState state, A value) Run(IsotopeSettings settings = null)
+        {
+            var res = Invoke(IsotopeState.Empty.With(Settings: settings));
+            if (res.State.Settings.DisposeOnCompletion)
+            {
+                res.State.DisposeWebDriver();
+            }
+            return(res.State, res.Value);
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public (IsotopeState state, A value) RunAndThrowOnError(IsotopeSettings settings = null)
+        {
+            var (state, value) = Run(settings);
+            state.IfFailedThrow();
+            return (state, value);
+        }
+
+        /// <summary>
+        /// Or operator - evaluates the left hand side, if it fails, it ignores the error and evaluates the right hand side
+        /// </summary>
+        public static Isotope<A> operator |(Isotope<A> lhs, Isotope<A> rhs) => 
+            new Isotope<A>(s =>
+            {
+                var l = lhs.Invoke(s);
+                var r = l.IsFaulted
+                           ? rhs.Invoke(s)
+                           : l;
+
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
+            });
+
+        /// <summary>
+        /// Lift the pure value into the monadic space 
+        /// </summary>
+        public static Isotope<A> Pure(A value) =>
+            new Isotope<A>(s => new IsotopeState<A>(value, s));
+        
+        /// <summary>
+        /// Lift the error into the monadic space 
+        /// </summary>
+        public static Isotope<A> Fail(Error error) =>
+            new Isotope<A>(s => new IsotopeState<A>(default(A), s.AddError(error)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<B> Bind<B>(Func<A, Isotope<B>> f)
+        {
+            var self = this;   
+            return new Isotope<B>(state => 
+            { 
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> Bind<Env, B>(Func<A, Isotope<Env, B>> f)
+        {
+            var self = this;   
+            return new Isotope<Env, B>((env, state) => 
+            { 
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> Bind<B>(Func<A, IsotopeAsync<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<B>(async state => 
+            { 
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<Env, B>(Func<A, IsotopeAsync<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<B> SelectMany<B>(Func<A, Isotope<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> SelectMany<Env, B>(Func<A, Isotope<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<B> SelectMany<B>(Func<A, IsotopeAsync<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<Env, B>(Func<A, IsotopeAsync<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<C> SelectMany<B, C>(Func<A, Isotope<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, C> SelectMany<Env, B, C>(Func<A, Isotope<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<C> SelectMany<B, C>(Func<A, IsotopeAsync<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<Env, B, C>(Func<A, IsotopeAsync<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public Isotope<B> Map<B>(Func<A, B> f)
+        {
+            var self = this;   
+            return new Isotope<B>(state => 
+            {
+                var s = self.Invoke(state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return new IsotopeState<B>(f(s.Value), s.State);
+            });
+        }
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public Isotope<B> Select<B>(Func<A, B> f) =>
+            Map(f);
+
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<A> MapFail(Func<Seq<Error>, Seq<Error>> f)
+        {
+            var self = this;
+            return new Isotope<A>(
+                s => {
+                    var r = self.Invoke(s);
+                    return r.IsFaulted
+                               ? new IsotopeState<A>(default, r.State.With(Error: f(r.State.Error)))
+                               : r;
+                });
+        }
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<B> BiMap<B>(Func<A, B> Succ,  Func<Seq<Error>, Seq<Error>> Fail)
+        {
+            var self = this;
+            return new Isotope<B>(
+                s => {
+                    var r = self.Invoke(s);
+                    return r.IsFaulted
+                               ? new IsotopeState<B>(default, r.State.With(Error: Fail(r.State.Error)))
+                               : new IsotopeState<B>(Succ(r.Value), r.State);
+                });
+        }
+        
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<A> MapFail(Func<Seq<Error>, Error> f) =>
+            MapFail(s => Seq1(f(s)));
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<B> BiMap<B>(Func<A, B> Succ, Func<Seq<Error>, Error> Fail) =>
+            BiMap(Succ, s => Seq1(Fail(s)));
+    }
+}

--- a/src/Isotope80/Isotope_Env_A.cs
+++ b/src/Isotope80/Isotope_Env_A.cs
@@ -50,11 +50,6 @@ namespace Isotope80
         public (IsotopeState state, A value) Run(Env env, IsotopeSettings settings = null)
         {
             var res = Invoke(env, IsotopeState.Empty.With(Settings: settings));
-            if (res.State.Settings.DisposeOnCompletion)
-            {
-                res.State.DisposeWebDriver();
-            }
-
             return (res.State, res.Value);
         }
 

--- a/src/Isotope80/Isotope_Env_A.cs
+++ b/src/Isotope80/Isotope_Env_A.cs
@@ -1,0 +1,284 @@
+using System;
+using LanguageExt;
+using LanguageExt.Common;
+using OpenQA.Selenium;
+using static LanguageExt.Prelude;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Isotope computation with an environment
+    /// </summary>
+    /// <typeparam name="Env">Environment</typeparam>
+    /// <typeparam name="A">Bound value</typeparam>
+    public struct Isotope<Env, A>
+    {
+        readonly Func<Env, IsotopeState, IsotopeState<A>> Thunk;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="thunk">Thunk</param>
+        public Isotope(Func<Env, IsotopeState, IsotopeState<A>> thunk) =>
+            Thunk = thunk;
+
+        /// <summary>
+        /// Invoke the computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="state">State</param>
+        /// <returns>Result of invoking the isotope computation</returns>
+        internal IsotopeState<A> Invoke(Env env, IsotopeState state)
+        {
+            try
+            {
+                return Thunk?.Invoke(env, state) ?? throw new InvalidOperationException("Isotope computation not initialised");
+            }
+            catch (Exception e)
+            {
+                return new IsotopeState<A>(default, state.AddError(Error.New(e)));
+            }
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public (IsotopeState state, A value) Run(Env env, IsotopeSettings settings = null)
+        {
+            var res = Invoke(env, IsotopeState.Empty.With(Settings: settings));
+            if (res.State.Settings.DisposeOnCompletion)
+            {
+                res.State.DisposeWebDriver();
+            }
+
+            return (res.State, res.Value);
+        }
+
+        /// <summary>
+        /// Invoke the test computation
+        /// </summary>
+        /// <param name="env">Environment</param>
+        /// <param name="settings">Optional settings</param>
+        /// <returns>Returning an optional error. 
+        /// The computation succeeds if result.IsNone is true</returns>
+        public (IsotopeState state, A value) RunAndThrowOnError(Env env, IsotopeSettings settings = null)
+        {
+            var (state, value) = Run(env, settings);
+            state.IfFailedThrow();
+            return (state, value);
+        }
+
+        /// <summary>
+        /// Implicit conversion 
+        /// </summary>
+        public static implicit operator Isotope<Env, A>(Isotope<A> ma) =>
+            new Isotope<Env, A>((_, state) => ma.Invoke(state));
+
+        /// <summary>
+        /// Or operator - evaluates the left hand side, if it fails, it ignores the error and evaluates the right hand side
+        /// </summary>
+        public static Isotope<Env, A> operator |(Isotope<Env, A> lhs, Isotope<Env, A> rhs) =>
+            new Isotope<Env, A>((e, s) => {
+                                    var l = lhs.Invoke(e, s);
+                                    var r = l.IsFaulted
+                                                ? rhs.Invoke(e, s)
+                                                : l;
+
+                                    return r.IsFaulted
+                                               ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                                               : r;
+                                });
+
+        /// <summary>
+        /// Lift the pure value into the monadic space 
+        /// </summary>
+        public static Isotope<Env, A> Pure(A value) =>
+            new Isotope<Env, A>((e, s) => new IsotopeState<A>(value, s));
+
+        /// <summary>
+        /// Lift the error into the monadic space 
+        /// </summary>
+        public static Isotope<Env, A> Fail(Error error) =>
+            new Isotope<Env, A>((e, s) => new IsotopeState<A>(default(A), s.AddError(error)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> Bind<B>(Func<A, Isotope<B>> f)
+        {
+            var self = this;   
+            return new Isotope<Env, B>((env, state) => 
+            { 
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> Bind<B>(Func<A, Isotope<Env, B>> f)
+        {
+            var self = this;   
+            return new Isotope<Env, B>((env, state) => 
+            { 
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, IsotopeAsync<B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> Bind<B>(Func<A, IsotopeAsync<Env, B>> f)
+        {
+            var self = this;   
+            return new IsotopeAsync<Env, B>(async (env, state) => 
+            { 
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return await f(s.Value).Invoke(env, s.State);
+            });
+        }
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> SelectMany<B>(Func<A, Isotope<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, B> SelectMany<B>(Func<A, Isotope<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, IsotopeAsync<B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, B> SelectMany<B>(Func<A, IsotopeAsync<Env, B>> f) =>
+            Bind(f);
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, C> SelectMany<B, C>(Func<A, Isotope<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public Isotope<Env, C> SelectMany<B, C>(Func<A, Isotope<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, IsotopeAsync<B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Monadic bind 
+        /// </summary>
+        public IsotopeAsync<Env, C> SelectMany<B, C>(Func<A, IsotopeAsync<Env, B>> bind, Func<A, B, C> project) =>
+            Bind(a => bind(a).Map(b => project(a, b)));
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public Isotope<Env, B> Map<B>(Func<A, B> f)
+        {
+            var self = this;   
+            return new Isotope<Env, B>((env, state) => 
+            {
+                var s = self.Invoke(env, state);
+                if (s.IsFaulted) return s.CastError<B>();
+                return new IsotopeState<B>(f(s.Value), s.State);
+            });
+        }
+
+        /// <summary>
+        /// Functor map
+        /// </summary>
+        public Isotope<Env, B> Select<B>(Func<A, B> f) =>
+            Map(f);
+
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<Env, A> MapFail(Func<Seq<Error>, Seq<Error>> f)
+        {
+            var self = this;
+            return new Isotope<Env, A>(
+                (e, s) => {
+                    var r = self.Invoke(e, s);
+                    return r.IsFaulted
+                               ? new IsotopeState<A>(default, r.State.With(Error: f(r.State.Error)))
+                               : r;
+                });
+        }
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<Env, B> BiMap<B>(Func<A, B> Succ,  Func<Seq<Error>, Seq<Error>> Fail)
+        {
+            var self = this;
+            return new Isotope<Env, B>(
+                (e, s) => {
+                    var r = self.Invoke(e, s);
+                    return r.IsFaulted
+                               ? new IsotopeState<B>(default, r.State.With(Error: Fail(r.State.Error)))
+                               : new IsotopeState<B>(Succ(r.Value), r.State);
+                });
+        }    
+        
+        /// <summary>
+        /// Map the alternative value (errors)
+        /// </summary>
+        /// <param name="f">Mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<Env, A> MapFail(Func<Seq<Error>, Error> f) =>
+            MapFail(s => Seq1(f(s)));
+
+        /// <summary>
+        /// Map both sides of the isotope (success and failure)
+        /// </summary>
+        /// <param name="Succ">Success mapping function</param>
+        /// <param name="Fail">Failure mapping function</param>
+        /// <returns>Mapped isotope computation</returns>
+        public Isotope<Env, B> BiMap<B>(Func<A, B> Succ, Func<Seq<Error>, Error> Fail) =>
+            BiMap(Succ, s => Seq1(Fail(s)));
+    }
+}

--- a/src/Isotope80/Log.cs
+++ b/src/Isotope80/Log.cs
@@ -38,7 +38,7 @@ namespace Isotope80
         /// <summary>
         /// Empty log
         /// </summary>
-        public static readonly Log Empty = new Log(-1, default, "", default);
+        public static readonly Log Empty = new Log(0, default, "", default);
         
         /// <summary>
         /// Number of tabs to indent
@@ -65,9 +65,9 @@ namespace Isotope80
         /// </summary>
         internal Log(int indent, LogType type, string message, Seq<Log> children)
         {
-            Indent   = indent;
+            Indent   = indent >= 0 ? indent : throw new ArgumentOutOfRangeException(nameof(indent));
             Type     = type;
-            Message  = message;
+            Message  = message ?? throw new ArgumentNullException(nameof(message));
             Children = children;
         }
 
@@ -131,7 +131,7 @@ namespace Isotope80
     /// <summary>
     /// Log output
     /// </summary>
-    public struct LogOutput
+    public readonly struct LogOutput
     {
         /// <summary>
         /// Log message
@@ -151,8 +151,12 @@ namespace Isotope80
         /// <summary>
         /// Ctor
         /// </summary>
-        public LogOutput(string message, LogType type, int index) =>
-            (Message, Type, Indent) = (message, type, Math.Max(0, index));
+        public LogOutput(string message, LogType type, int indent)
+        {
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            Type    = type;
+            Indent  = indent >= 0 ? indent :  throw new ArgumentOutOfRangeException(nameof(indent));
+        }
 
         /// <summary>
         /// Tabbed format display 

--- a/src/Isotope80/Log.cs
+++ b/src/Isotope80/Log.cs
@@ -4,93 +4,160 @@ using static LanguageExt.Prelude;
 
 namespace Isotope80
 {
-    public class Log
+    /// <summary>
+    /// Log entry type
+    /// </summary>
+    public enum LogType
     {
-        private readonly Seq<Node> Nodes;
-        private readonly Option<Node> Current;
-
-        public Log(Seq<Node> nodes, Option<Node> current)
-        {
-            Nodes = nodes;
-            Current = current;
-        }
-
-        public Log With(Seq<Node>? nodes = null, Option<Node>? current = null) =>
-            new Log(nodes ?? Nodes, current ?? Current);
-
-        public Log Append(string message, Action<string, int> action, int depth = 0) =>
-            Current.Match(
-                Some: x => With(current: x.Append(message, action, depth)),
-                None: () => {
-                    action(message, depth);
-                    return With(nodes: Nodes.Add(Node.New(message)));
-                });
-
-        public Log Push(string message, Action<string, int> action, int depth = 0) =>
-            Current.Match(
-                Some: x => With(current: x.Push(message, action, depth)),
-                None: () => {
-                    action(message, depth);
-                    return With(current: Node.New(message));
-                });
-
-        public Log Pop() =>
-            Current.Match(
-                Some: x => x.Children.Current.IsSome
-                           ? With(current: x.Pop())
-                           : With(nodes: Nodes.Add(x), current: None),
-                None: () => this);
-
-        public static Log Empty => new Log(new Seq<Node>(), None);
-
-        public override string ToString() =>
-            string.Join(Environment.NewLine, ToString(0));
-
-        public Seq<string> ToString(int indent) =>
-            Nodes
-                .Append(Current.ToSeq())
-                .Bind(x => x.ToString(indent));
-
-        public string Trace() =>
-            string.Join(Environment.NewLine, Trace(0));
-
-        public Seq<string> Trace(int indent) =>
-            Nodes.Map(x => new string('\t', indent) + x.Message)
-                 .Append(Current.Bind(x => x.Trace(indent)))
-                 .ToSeq();
+        /// <summary>
+        /// Contextual header
+        /// </summary>
+        Context,
+        
+        /// <summary>
+        /// Information message
+        /// </summary>
+        Info,
+        
+        /// <summary>
+        /// Warning message
+        /// </summary>
+        Warn,
+        
+        /// <summary>
+        /// Error message
+        /// </summary>
+        Error
     }
 
-    public class Node
+    /// <summary>
+    /// Nested log
+    /// </summary>
+    public class Log
     {
-        public readonly string Message;
-        public readonly Log Children;
+        /// <summary>
+        /// Empty log
+        /// </summary>
+        public static readonly Log Empty = new Log(-1, default, "", default);
+        
+        /// <summary>
+        /// Number of tabs to indent
+        /// </summary>
+        public readonly int Indent;
 
-        private Node(string message, Log children)
+        /// <summary>
+        /// Log type
+        /// </summary>
+        public readonly LogType Type;
+        
+        /// <summary>
+        /// Node message
+        /// </summary>
+        public readonly string Message;
+        
+        /// <summary>
+        /// Child messages
+        /// </summary>
+        public readonly Seq<Log> Children;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        internal Log(int indent, LogType type, string message, Seq<Log> children)
         {
-            Message = message;
+            Indent   = indent;
+            Type     = type;
+            Message  = message;
             Children = children;
         }
 
-        public Node With(string message = null, Log children = null) =>
-            new Node(message ?? Message, children ?? Children);
+        /// <summary>
+        /// Add a message to the log
+        /// </summary>
+        /// <param name="ctx">Context</param>
+        public (Log Parent, Log Child) Context(string ctx)
+        {
+            var child = new Log(Indent + 1, LogType.Info, ctx, default);
+            return (new Log(Indent, Type, Message, Children.Add(child)), child);
+        }
 
-        public Node Append(string message, Action<string, int> action, int depth) => 
-            With(children: Children.Append(message, action, depth+1));
+        /// <summary>
+        /// Add a log entry
+        /// </summary>
+        public Log Add(Log log) =>
+            new Log(Indent, Type, Message, Children.Add(log));
 
-        public Node Push(string message, Action<string, int> action, int depth) => 
-            With(children: Children.Push(message, action, depth+1));
+        /// <summary>
+        /// Add a message to the log
+        /// </summary>
+        /// <param name="message">Message to log</param>
+        public Log Info(string message) =>
+            new Log(Indent, Type, Message, Children.Add(new Log(Indent + 1, LogType.Info, $"INFO: {message}", default))); 
 
-        public Node Pop() => With(children: Children.Pop());
+        /// <summary>
+        /// Add a message to the log
+        /// </summary>
+        /// <param name="message">Message to log</param>
+        public Log Warning(string message) =>
+            new Log(Indent, Type, Message, Children.Add(new Log(Indent + 1, LogType.Warn, $"WARN: {message}", default)));
 
-        public static Node New(string message) => new Node(message, Log.Empty);
+        /// <summary>
+        /// Add a message to the log
+        /// </summary>
+        /// <param name="message">Message to log</param>
+        public Log Error(string message) =>
+            new Log(Indent, Type, Message, Children.Add(new Log(Indent + 1, LogType.Error, $"ERRO: {message}", default)));
 
-        public Seq<string> ToString(int indent) =>
-            Seq1(new string('\t', indent) + Message)
-                .Append(Children.ToString(++indent));
+        /// <summary>
+        /// Create a new Node
+        /// </summary>
+        public static Log New(string message) => 
+            new Log(0, LogType.Info, message, default);
 
-        public Seq<string> Trace(int indent) =>
-            Seq1(new string('\t', indent) + Message)
-               .Append(Children.Trace(++indent));
+        /// <summary>
+        /// ToString
+        /// </summary>
+        public override string ToString() =>
+            String.Join(Environment.NewLine, ToSeq());
 
+        /// <summary>
+        /// ToSeq
+        /// </summary>
+        public Seq<string> ToSeq() =>
+            Seq1(new string('\t', Indent) + Message)
+                .Append(Children.Map(c => c.ToSeq()));
+    }
+
+    /// <summary>
+    /// Log output
+    /// </summary>
+    public struct LogOutput
+    {
+        /// <summary>
+        /// Log message
+        /// </summary>
+        public readonly string Message;
+        
+        /// <summary>
+        /// Severity type
+        /// </summary>
+        public readonly LogType Type;
+        
+        /// <summary>
+        /// Indentation
+        /// </summary>
+        public readonly int Indent;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        public LogOutput(string message, LogType type, int index) =>
+            (Message, Type, Indent) = (message, type, Math.Max(0, index));
+
+        /// <summary>
+        /// Tabbed format display 
+        /// </summary>
+        public override string ToString() =>
+            new string('\t', Indent) + Message;
     }
 }

--- a/src/Isotope80/Query.cs
+++ b/src/Isotope80/Query.cs
@@ -419,24 +419,4 @@ namespace Isotope80
         public Query Empty() =>
             Query.Identity;
     }
-
-    /// <summary>
-    /// Head
-    /// </summary>
-    internal class ByHead : By
-    {
-        public ByHead() : base(
-            context => ((IFindsByClassName) context).FindElementByClassName("*"),
-            context => Head(((IFindsByClassName) context).FindElementsByClassName("*")))
-        {
-        }
-
-        static ReadOnlyCollection<A> Head<A>(ReadOnlyCollection<A> many)
-        {
-            if (many.Count == 0) return many;
-            var list = new List<A>();
-            list.Add(many.First());
-            return new ReadOnlyCollection<A>(list);
-        }
-    }
 }

--- a/src/Isotope80/Query.cs
+++ b/src/Isotope80/Query.cs
@@ -1,0 +1,442 @@
+using System.Collections.ObjectModel;
+using static LanguageExt.Prelude;
+using System.Collections.Generic;
+using static Isotope80.Isotope;
+using OpenQA.Selenium.Internal;
+using LanguageExt.TypeClasses;
+using System.Globalization;
+using OpenQA.Selenium;
+using System.Linq;
+using LanguageExt;
+using System;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Query selector
+    /// </summary>
+    /// <remarks>
+    /// Queries can be composed associatively. The left-hand-side query gets refined by the right-hand-side.
+    /// Identity selects all.
+    /// </remarks>
+    public class Query
+    {
+        readonly Seq<QueryStep> arrows;
+
+        /// <summary>
+        /// Query
+        /// </summary>
+        Query(Seq<QueryStep> arrows) =>
+            this.arrows = arrows;
+
+        /// <summary>
+        /// Identity query
+        /// </summary>
+        /// <remarks>By supporting identity and `+` Query becomes a monoid</remarks>
+        public static readonly Query Identity =
+            byCss("*");
+
+        /// <summary>
+        /// Create a Query from a By
+        /// </summary>
+        /// <param name="by">Selector arrows</param>
+        /// <returns>Query</returns>
+        public static Query fromBy(params By[] by) =>
+            new Query(by.ToSeq().Map(QueryStepCon.ByStep).Strict());
+
+        /// <summary>
+        /// Query an element by identifier
+        /// </summary>
+        /// <param name="id">Identifier of the element</param>
+        /// <returns>Query</returns>
+        public static Query byId(string id) =>
+            By.Id(id);
+
+        /// <summary>
+        /// Query elements by the text within a link
+        /// </summary>
+        /// <param name="linkTextToFind">Link text to find</param>
+        /// <returns>Query</returns>
+        public static Query byLinkText(string linkTextToFind) =>
+            By.LinkText(linkTextToFind);
+
+        /// <summary>
+        /// Query elements by name attribute
+        /// </summary>
+        /// <param name="name">Name o</param>
+        /// <returns>Query</returns>
+        public static Query byName(string name) =>
+            By.Name(name);
+
+        /// <summary>
+        /// Query elements using a CSS selector
+        /// </summary>
+        /// <param name="selector">CSS selector</param>
+        /// <returns>Query</returns>
+        public static Query byCss(string selector) =>
+            By.CssSelector(selector);
+
+        /// <summary>
+        /// Query elements by tag-name
+        /// </summary>
+        /// <param name="tagName">Tag name</param>
+        /// <returns>Query</returns>
+        public static Query byTag(string tagName) =>
+            By.TagName(tagName);
+
+        /// <summary>
+        /// Query elements by XPath
+        /// </summary>
+        /// <param name="xpath">XPath selector</param>
+        /// <returns>Query</returns>
+        public static Query byXPath(string xpath) =>
+            By.XPath(xpath);
+
+        /// <summary>
+        /// Wait until element exists query
+        /// </summary>
+        /// <param name="interval">Optional interval between checks</param>
+        /// <param name="wait">Optional total wait time</param>
+        /// <returns>Query</returns>
+        internal static Query waitUntilElementExists(Option<TimeSpan> interval = default, Option<TimeSpan> wait = default) =>
+            waitUntil(es => es.IsEmpty
+                                ? fail<Unit>("No elements")
+                                : pure(unit),
+                      "waitUntilElementExists",
+                      interval,
+                      wait);
+
+        /// <summary>
+        /// Query the first element
+        /// </summary>
+        /// <returns>Query</returns>
+        public static Query byHead =
+            filter(es => es.IsEmpty
+                             ? fail<Unit>("No elements: expected a head element")
+                             : pure(unit),
+                   "head");
+
+        /// <summary>
+        /// Query the first element and only the first.  Multiple elements is failure 
+        /// </summary>
+        /// <returns>Query</returns>
+        public static Query bySingle =
+            filter(es => es.IsEmpty
+                             ? fail<Unit>("No elements: expected one element")
+                             : es.Tail.IsEmpty
+                                 ? pure(unit)
+                                 : fail<Unit>("Too many elements: expected only one"),
+                  "single");
+        
+        /// <summary>
+        /// Filter with an Isotope: fail means filtered out, success means let through
+        /// The error reported by the Isotope is used as the final error 
+        /// </summary>
+        static Query filter(Func<Seq<IWebElement>, Isotope<Unit>> f, string desc) => 
+            new Query(Seq1(QueryStepCon.FilterM(f, desc)));
+        
+        /// <summary>
+        /// Filter with an Isotope: fail means filtered out, success means let through
+        /// The error reported by the Isotope is used as the final error
+        ///
+        /// Differs from filter in that it retries until timeout 
+        /// </summary>
+        static Query waitUntil(Func<Seq<IWebElement>, Isotope<Unit>> f, string desc, Option<TimeSpan> interval = default, Option<TimeSpan> wait = default) => 
+            new Query(Seq1(QueryStepCon.WaitM(f, desc, interval, wait)));
+        
+        /// <summary>
+        /// Conversion operator 
+        /// </summary>
+        public static implicit operator Query(By by) =>
+            new Query(Seq1(QueryStepCon.ByStep(by)));
+
+        /// <summary>
+        /// Associative query composition
+        /// </summary>
+        /// <remarks>Queries can be composed associatively. The left-hand-side query gets refined by the right-hand-side.</remarks>
+        /// <param name="lhs"></param>
+        /// <param name="rhs"></param>
+        /// <returns></returns>
+        public static Query operator +(Query lhs, Query rhs) =>
+            new Query(lhs.arrows + rhs.arrows);
+
+        /// <summary>
+        /// Query an element by identifier
+        /// </summary>
+        /// <param name="id">Identifier of the element</param>
+        /// <returns>Query</returns>
+        public Query WhereId(string id) =>
+            this + byId(id);
+
+        /// <summary>
+        /// Query elements by the text within a link
+        /// </summary>
+        /// <param name="linkTextToFind">Link text to find</param>
+        /// <returns>Query</returns>
+        public Query WhereLinkText(string linkTextToFind) =>
+            this + byLinkText(linkTextToFind);
+
+        /// <summary>
+        /// Query elements by name attribute
+        /// </summary>
+        /// <param name="name">Name o</param>
+        /// <returns>Query</returns>
+        public Query WhereName(string name) =>
+            this + byName(name);
+
+        /// <summary>
+        /// Query elements using a CSS selector
+        /// </summary>
+        /// <param name="selector">CSS selector</param>
+        /// <returns>Query</returns>
+        public Query WhereCss(string selector) =>
+            this + byCss(selector);
+
+        /// <summary>
+        /// Query elements by tag-name
+        /// </summary>
+        /// <param name="tagName">Tag name</param>
+        /// <returns>Query</returns>
+        public Query WhereTag(string tagName) =>
+            this + byTag(tagName);
+
+        /// <summary>
+        /// Query elements by XPath
+        /// </summary>
+        /// <param name="xpath">XPath selector</param>
+        /// <returns>Query</returns>
+        public Query WhereXPath(string xpath) =>
+            this + byXPath(xpath);
+
+        /// <summary>
+        /// Query the first element
+        /// </summary>
+        /// <returns>Query</returns>
+        public Query Head =>
+            this + byHead;
+
+        /// <summary>
+        /// Query the first element
+        /// </summary>
+        /// <returns>Query</returns>
+        public Query Single =>
+            this + bySingle;
+
+        /// <summary>
+        /// Wait until element exists query
+        /// </summary>
+        /// <param name="interval">Optional interval between checks</param>
+        /// <param name="wait">Optional total wait time</param>
+        /// <returns>Query</returns>
+        public Query WaitUntilElementExists(Option<TimeSpan> interval = default, Option<TimeSpan> wait = default) =>
+            this + waitUntilElementExists(interval, wait);
+
+        /// <summary>
+        /// Maps the query to a runnable Isotope computation that returns the first item.  If there's 0 or more than 1
+        /// item then it fails.
+        /// </summary>
+        /// <returns></returns>
+        internal Isotope<IWebElement> ToIsotope1() =>
+            ToIsotope().Bind(es => es.Count switch
+                                   {
+                                       0 => fail<IWebElement>("Element not found"),
+                                       1 => pure(es.Head),
+                                       _ => fail<IWebElement>("More than one element found that matches the selector")
+                                   });
+
+        /// <summary>
+        /// Maps the query to a runnable Isotope computation that returns the first item or fails
+        /// </summary>
+        /// <returns></returns>
+        internal Isotope<IWebElement> ToIsotopeHead() =>
+            ToIsotope().Bind(es => es.Count switch
+                                   {
+                                       0 => fail<IWebElement>("Element not found"),
+                                       _ => pure(es.Head)
+                                   });
+
+        /// <summary>
+        /// Maps the query to a runnable Isotope computation that returns the first item or fails
+        /// </summary>
+        /// <returns></returns>
+        internal Isotope<Option<IWebElement>> ToIsotopeHeadOrNone() =>
+            ToIsotope().Bind(es => es.Count switch
+                                   {
+                                       0 => pure<Option<IWebElement>>(None),
+                                       _ => pure(Some(es.Head))
+                                   });
+
+        /// <summary>
+        /// Maps the query to a runnable Isotope computation
+        /// </summary>
+        /// <returns></returns>
+        internal Isotope<Seq<IWebElement>> ToIsotope()
+        {
+            var ma = pure(Option<Seq<IWebElement>>.None);
+            
+            foreach (var arr in arrows)
+            {
+                if (arr is ByStep byStep)
+                {
+                    ma = from op in ma
+                         from rs in op.Match(
+                             
+                             // If we haven't selected anything yet, start by selecting via the web-driver using the `by`
+                             None: () => from dr in webDriver
+                                         from es in iso(() => dr.FindElements(byStep.Value).ToSeq().Strict()) | fail<Seq<IWebElement>>("No elements found")
+                                         select Some(es),
+                             
+                             // If we have selected something, let's use that as a filter going forward
+                             Some: ws => ws.IsEmpty
+                                         
+                                             // Nothing selected, so short cut
+                                             ? pure(Some(ws))
+                                             
+                                             // Apply the `by` to each selected element 
+                                             : from r in ws.Fold(
+                                                   pure(Seq<IWebElement>()), 
+                                                   (s, w) =>
+                                                        from os in s
+                                                        from ns in iso(() => w.FindElements(byStep.Value).ToSeq().Strict()) | fail<Seq<IWebElement>>("No elements found")
+                                                        select os + ns)
+                                               select Some(r))
+                         select rs;
+                }
+                else if (arr is WaitM waitM)
+                {
+                    ma = Isotope.waitUntil(
+                        from a in ma
+                        from r in a.Match(
+                            None: fail<Unit>("WaitM until must follow a something that queries elements.  It can't run alone"),
+                            Some: waitM.Ma)
+                        select a);
+                }
+                else if (arr is FilterM filterM)
+                {
+                    ma = from a in ma
+                         from r in a.Match(
+                            None: fail<Unit>("FilterM until must follow a something that queries elements.  It can't run alone"),
+                            Some: filterM.Ma)
+                         select a;
+                }
+            }
+
+            return ma.Map(op => op.IfNone(Empty));
+        }
+
+        /// <summary>
+        /// Maps the query to a runnable Isotope computation
+        /// </summary>
+        /// <returns></returns>
+        public Isotope<Seq<WebElement>> ToSeq() =>
+            ToIsotope().Map(es => es.Map<IWebElement, WebElement>((ix, e) => WebElement.New(this, ix, e.TagName, e.Text, e.Enabled, e.Selected, e.Location, e.Size, e.Displayed))
+                                    .ToSeq()
+                                    .Strict());
+
+        /// <summary>
+        /// Migration of the IWebElement.PrettyPrint
+        /// TODO: Make this a bit more elegant
+        /// </summary>
+        /// <returns></returns>
+        public Isotope<string> PrettyPrint() =>
+            ToIsotopeHead().Map(IsotopeInternal.prettyPrint);
+
+        /// <summary>
+        /// To string
+        /// </summary>
+        public override string ToString() =>
+            String.Join(" → ", arrows);
+    }
+
+    /// <summary>
+    /// Step in a query
+    /// </summary>
+    [Union]
+    internal interface QueryStep
+    {
+        /// <summary>
+        /// Selector step - filters by `value`
+        /// </summary>
+        QueryStep ByStep(By value);
+        
+        /// <summary>
+        /// Like a LINQ Where, but instead of bool return it returns an Isotope, which means we can propagate errors
+        /// </summary>
+        QueryStep FilterM(Func<Seq<IWebElement>, Isotope<Unit>> ma, string desc);
+        
+        /// <summary>
+        /// Like a LINQ Where, but instead of bool return it returns an Isotope, which means we can propagate errors
+        /// It differs from FilterM in that it waits for a period of time, retrying, until a timeout 
+        /// </summary>
+        QueryStep WaitM(Func<Seq<IWebElement>, Isotope<Unit>> ma, string desc,  Option<TimeSpan> interval = default, Option<TimeSpan> wait = default);
+    }
+    
+    internal static class QueryStepExt
+    {
+        internal static string Show(QueryStep step) =>
+            step switch
+            {
+                ByStep  (var value)                   => value.ToString(),
+                FilterM (var _, var d)                => d,
+                WaitM   (var _, var d, var _, var _)  => d,
+                _                                     => throw new NotSupportedException()
+            };
+    }
+
+    /// <summary>
+    /// Query semigroup instance
+    /// </summary>
+    public struct SemiQuery : Semigroup<Query>
+    {
+        /// <summary>
+        /// Associative binary operator for query composition
+        /// </summary>
+        /// <param name="x">Left query</param>
+        /// <param name="y">Right query</param>
+        /// <returns>Composed query</returns>
+        public Query Append(Query x, Query y) =>
+            x + y;
+    }
+
+    /// <summary>
+    /// Query monoid instance
+    /// </summary>
+    public struct MQuery : Monoid<Query>
+    {
+        /// <summary>
+        /// Associative binary operator for query composition
+        /// </summary>
+        /// <param name="x">Left query</param>
+        /// <param name="y">Right query</param>
+        /// <returns>Composed query</returns>
+        public Query Append(Query x, Query y) =>
+            x + y;
+
+        /// <summary>
+        /// Monoidal unit.  For Query this selects all.
+        /// </summary>
+        /// <returns>Unit query</returns>
+        public Query Empty() =>
+            Query.Identity;
+    }
+
+    /// <summary>
+    /// Head
+    /// </summary>
+    internal class ByHead : By
+    {
+        public ByHead() : base(
+            context => ((IFindsByClassName) context).FindElementByClassName("*"),
+            context => Head(((IFindsByClassName) context).FindElementsByClassName("*")))
+        {
+        }
+
+        static ReadOnlyCollection<A> Head<A>(ReadOnlyCollection<A> many)
+        {
+            if (many.Count == 0) return many;
+            var list = new List<A>();
+            list.Add(many.First());
+            return new ReadOnlyCollection<A>(list);
+        }
+    }
+}

--- a/src/Isotope80/WebDriverSelect.cs
+++ b/src/Isotope80/WebDriverSelect.cs
@@ -1,0 +1,28 @@
+namespace Isotope80
+{
+    /// <summary>
+    /// Web driver selector
+    /// </summary>
+    public enum WebDriverSelect
+    {
+        /// <summary>
+        /// Google Chrome web-browser
+        /// </summary>
+        Chrome,
+
+        /// <summary>
+        /// Microsoft Edge web-browser
+        /// </summary>
+        Edge,
+
+        /// <summary>
+        /// Mozilla Firefox web-browser
+        /// </summary>
+        Firefox,
+       
+        /// <summary>
+        /// Microsoft Internet Explorer web-browser
+        /// </summary>
+        InternetExplorer
+    }
+}

--- a/src/Isotope80/WebElement.cs
+++ b/src/Isotope80/WebElement.cs
@@ -1,0 +1,60 @@
+using System.Drawing;
+using LanguageExt;
+
+namespace Isotope80
+{
+    /// <summary>
+    /// Immutable web-element that doesn't suffer the problems of the lazy IWebElement (namely if the IWebDriver is
+    /// disposed then IWebElement fails, which is a problem for lazy processes).
+    /// </summary>
+    [Record]
+    public partial class WebElement
+    {
+        /// <summary>
+        /// Query selector that found this element
+        /// </summary>
+        public readonly Query Selector;
+        
+        /// <summary>
+        /// This structure was made from a query.  This is the index into the query results
+        /// </summary>
+        public readonly int SelectionIndex;
+        
+        /// <summary>
+        /// Element tag name
+        /// </summary>
+        public readonly string TagName;
+        
+        // <summary>
+        // Element inner text
+        // </summary>
+        public readonly string Text;
+
+        /// <summary>
+        /// Element enabled flag
+        /// </summary>
+        public readonly bool Enabled;
+
+        /// <summary>
+        /// Indicates whether or not this element is selected.
+        /// </summary>
+        public readonly bool Selected;
+
+        /// <summary>
+        /// Gets a <see cref="T:System.Drawing.Point" /> object containing the coordinates of the upper-left corner
+        /// of this element relative to the upper-left corner of the page.
+        /// </summary>
+        public readonly Point Location;
+
+        /// <summary>
+        /// Gets a <see cref="P:OpenQA.Selenium.IWebElement.Size" /> object containing the height and width of this element.
+        /// </summary>
+        /// <exception cref="T:OpenQA.Selenium.StaleElementReferenceException">Thrown when the target element is no longer valid in the document DOM.</exception>
+        public readonly Size Size;
+
+        /// <summary>
+        /// Indicates whether or not this element is displayed.
+        /// </summary>
+        public readonly bool Displayed;
+    }
+}


### PR DESCRIPTION
I'm submitting this early as it has breaking changes, and it'd be good to get feedback on the approach.  

There's a new type called `Query` that is a composable mini-DSL.  Compositions are associative.

Example:
```c#
    var qry = Query.byId("test");
```
Queries can be refined either by calling their fluent methods or adding them `+`:

The follow two examples are the same:
```c#
   using static Isotope80.Query;

   var qry1 = byTag("input") + byName("test");
   var qry1 = byTag("input").WhereName("test");
```
The query system extends beyond the basic selectors in Selenium, and can wait, or enforce conditions:
```c#
    // There must be only one element with the `test` name
    var qry = byName("test").Single;

    // Expected at least one element with the `test` name
    var qry = byName("test").Head;

    // Wait for at least one element with the name `test` to exist
    var qry = byName("test").WaitUntilElementExists();
```
There are several `internal` methods on `Query` to convert it to an `Isotope`:
```c#
    // Maps the query to a runnable Isotope computation (returns IWebElement)
    // There must be only one element
    query.ToIsotope1()

    // Maps the query to a runnable Isotope computation (returns IWebElement)
    // There must be at least one element
    query.ToIsotopeHead()

    // Maps the query to a runnable Isotope computation (returns Option of IWebElement)
    query.ToIsotopeHeadOrNone()

    // Maps the query to a runnable Isotope computation (returns Seq of IWebElements)
    query.ToIsotope()

    // This is the same as `ToIsotope()` except it maps the `IWebElement` items to a new 
    // immutable type called `WebElement`
    query.ToSeq();
```
These internal methods are used in the `Isotope` functions to get access to the `IWebElement` items.

> NOTE: There may seem to be some overlap between the `Single`, `Head`, and `ToIsotope1`, `ToIsotopeHead`, etc.  The former are for the users to specify the constraints they care about, the later are to simplify usage in the internal `Isotope` functions.

I've refactored the `Isotope` static class:

* Moved all functions that used `IWebElement` and moved them to a new static class called `IsotopeInternal`
   * This is because we still want to leverage `IWebElement` internally, just not expose them.
* All functions that took a `By` now take a `Query`. 
   * There is an `implicit` conversion operator from `By` to `Query` to make migration simpler.
* Where there were functions that only had a variant that took a `IWebElement` I have added one that takes a `Query`.
* Updated the `findElement*` functions to return `WebElement` rather than `IWebElement`.  
   * The expectation is that the `findElement` functions should be used to interrogate the state of `WebElement` types, not to then use them to do more queries or interactions.
   * So I would expect fewer functions that take a `WebElement` than those that take a `Query`.
* Removed the `wait` and `error` arguments from the `findElement*` functions
   * Overriding errors should be done by using the `|` operator, i.e. `findElement(selector) | fail<WebElement>("damn")`
   * The `wait` flag can be achieved by calling `q.WaitUntilElementExists()` on the query.
   * This massive simplifies much of the code where these variants are needed
* I've marked `findElementOptional` as `Obsolete` this is another reason to use the `|` operator, to provide an alternative computation when `findElement` fails.
* I've maintained the child search `findElement*` functions for now, but they're kinda pointless.  As you can see below, it just composes the selector from the parent and the child selector:
```c#
        /// <summary>
        /// Find an HTML element within another
        /// </summary>
        /// <param name="element">Element to search</param>
        /// <param name="selector">Child element selector</param>
        public static Isotope<WebElement> findElement(WebElement element, Query selector) =>
            findElement(element.Selector + selector);
```
* Refactored the `Assertions` slightly to use the new setup, but also to clean it up a bit.
* Some isotopes that would return `bool` or `Option` I've started changing them to use `fail`.  We have an optional monad, so leveraging that with `|` is the better way to deal with optional paths.  We should look at the API as a whole, and look to define a style guide so that there's a _one true way_ to implement isotopes.
* More documentation

Obviously, there aren't enough unit tests to show the impact of the change.  But I needed to do very little to make it compile.  That's not saying much though.  So it would be good to understand the impact.