### PR TITLE
Loggiing improvements - caller file & line captured

### DIFF
--- a/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
+++ b/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
@@ -3,6 +3,7 @@ using System;
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
+using Xunit.Abstractions;
 using static LanguageExt.Prelude;
 using static System.Console;
 using static Isotope80.Isotope;
@@ -11,6 +12,13 @@ namespace Isotope80.Samples.UnitTests
 {
     public class LoggingTests
     {
+        protected readonly ITestOutputHelper Output;
+
+        public LoggingTests(ITestOutputHelper output)
+        {
+            Output = output;
+        }
+        
         [Fact]
         public void TestNestedContextualLogs()
         {
@@ -30,6 +38,7 @@ namespace Isotope80.Samples.UnitTests
             
             var stgs = IsotopeSettings.Create();
             stgs.LogStream.Subscribe(x => logs = logs.Add(x.ToString()));
+            stgs.LogStream.Subscribe(x => Output.WriteLine(x.ToStringWithPath()));
 
             var iso2 = from _ in info("Info log")
                        from r in context("Test 1",

--- a/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
+++ b/samples/Isotope80.Samples.UnitTests/LoggingTests.cs
@@ -38,7 +38,7 @@ namespace Isotope80.Samples.UnitTests
             
             var stgs = IsotopeSettings.Create();
             stgs.LogStream.Subscribe(x => logs = logs.Add(x.ToString()));
-            stgs.LogStream.Subscribe(x => Output.WriteLine(x.ToStringWithPath()));
+            stgs.LogStream.Subscribe(x => Output.WriteLine(x.ToVerboseString()));
 
             var iso2 = from _ in info("Info log")
                        from r in context("Test 1",

--- a/src/Isotope80/Internal/Text.cs
+++ b/src/Isotope80/Internal/Text.cs
@@ -11,10 +11,16 @@ namespace Isotope80
         /// <summary>
         /// Build a new string with `indent` tabs before
         /// </summary>
-        public static string Tabs(int indent, string str) =>
+        public static string Tabs(int indent) =>
             indent < tabs.Length
-                ? $"{tabs[indent]}{str}"
-                : $"{String.Concat(Range(0, indent).Map(_ => "    "))}{str}";
+                ? $"{tabs[indent]}"
+                : $"{String.Concat(Range(0, indent).Map(_ => "    "))}";
+
+        /// <summary>
+        /// Build a new string with `indent` tabs before
+        /// </summary>
+        public static string Tabs(int indent, string str) =>
+            $"{Tabs(indent)}{str}";
 
         /// <summary>
         /// Lookup table of tabs

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -1020,7 +1020,7 @@ namespace Isotope80
             [CallerFilePath] string callerFilePath = "", 
             [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = s.Log.Add(Log.Info(message, callerMemberName, callerFilePath, callerLineNumber))
+            let p = s.Log.Add(Log.Info(message, DateTime.UtcNow, callerMemberName, callerFilePath, callerLineNumber))
             from x in put(s.With(Log: p.Log))
             from y in writeToLogStream(p.Added)
             select unit;
@@ -1034,7 +1034,7 @@ namespace Isotope80
             [CallerFilePath] string callerFilePath = "", 
             [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = s.Log.Add(Log.Info(message, callerMemberName, callerFilePath, callerLineNumber))
+            let p = s.Log.Add(Log.Info(message, DateTime.UtcNow, callerMemberName, callerFilePath, callerLineNumber))
             from x in put(s.With(Log: p.Log))
             from y in writeToLogStream(p.Added)
             select unit;
@@ -1048,7 +1048,7 @@ namespace Isotope80
             [CallerFilePath] string callerFilePath = "", 
             [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = s.Log.Add(Log.Warning(message, callerMemberName, callerFilePath, callerLineNumber))
+            let p = s.Log.Add(Log.Warning(message, DateTime.UtcNow, callerMemberName, callerFilePath, callerLineNumber))
             from x in put(s.With(Log: p.Log))
             from y in writeToLogStream(p.Added)
             select unit;
@@ -1064,7 +1064,7 @@ namespace Isotope80
             [CallerFilePath] string callerFilePath = "", 
             [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = s.Log.Add(Log.Error(message, callerMemberName, callerFilePath, callerLineNumber))
+            let p = s.Log.Add(Log.Error(message, DateTime.UtcNow, callerMemberName, callerFilePath, callerLineNumber))
             from x in put(s.With(Log: p.Log))
             from y in writeToLogStream(p.Added)
             select unit;
@@ -1079,7 +1079,7 @@ namespace Isotope80
             [CallerFilePath] string callerFilePath = "", 
             [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = Log.Context(context, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
+            let p = Log.Context(context, DateTime.UtcNow, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
             from y in writeToLogStream(p)
             from x in put(s.With(Log: p, Context: s.Context.Push(context)))
             from r in iso
@@ -1097,7 +1097,7 @@ namespace Isotope80
             [CallerFilePath] string callerFilePath = "", 
             [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = Log.Context(context, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
+            let p = Log.Context(context, DateTime.UtcNow, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
             from y in writeToLogStream(p)
             from x in put(s.With(Log: p, Context: s.Context.Push(context)))
             from r in iso
@@ -1115,7 +1115,7 @@ namespace Isotope80
             [CallerFilePath] string callerFilePath = "", 
             [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = Log.Context(context, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
+            let p = Log.Context(context, DateTime.UtcNow, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
             from y in writeToLogStream(p)
             from x in put(s.With(Log: p, Context: s.Context.Push(context)))
             from r in iso
@@ -1133,7 +1133,7 @@ namespace Isotope80
             [CallerFilePath] string callerFilePath = "", 
             [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = Log.Context(context, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
+            let p = Log.Context(context, DateTime.UtcNow, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
             from y in writeToLogStream(p)
             from x in put(s.With(Log: p, Context: s.Context.Push(context)))
             from r in iso
@@ -1145,7 +1145,7 @@ namespace Isotope80
             new Isotope<Unit>(s => {
                   if (!String.IsNullOrWhiteSpace(entry.Message))
                   {
-                      s.Settings.LogStream.OnNext(new LogOutput(entry.Message, entry.Type, s.Context.Count, entry.CallerMemberName, entry.CallerFilePath, entry.CallerLineNumber));
+                      s.Settings.LogStream.OnNext(new LogOutput(entry.Message, entry.Type, s.Context.Count, entry.Time, entry.CallerMemberName, entry.CallerFilePath, entry.CallerLineNumber));
                   }
                   return new IsotopeState<Unit>(default, s);
               });

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using LanguageExt.Common;
@@ -1013,9 +1014,13 @@ namespace Isotope80
         /// Log some output
         /// </summary>
         [Obsolete("Use `info | warn | error` instead")]
-        public static Isotope<Unit> log(string message) =>
+        public static Isotope<Unit> log(
+            string message,
+            [CallerMemberName] string callerMemberName = "", 
+            [CallerFilePath] string callerFilePath = "", 
+            [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = s.Log.Add(Log.Info(message))
+            let p = s.Log.Add(Log.Info(message, callerMemberName, callerFilePath, callerLineNumber))
             from x in put(s.With(Log: p.Log))
             from y in writeToLogStream(p.Added)
             select unit;
@@ -1023,9 +1028,13 @@ namespace Isotope80
         /// <summary>
         /// Log some output as info
         /// </summary>
-        public static Isotope<Unit> info(string message) =>
+        public static Isotope<Unit> info(
+            string message,
+            [CallerMemberName] string callerMemberName = "", 
+            [CallerFilePath] string callerFilePath = "", 
+            [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = s.Log.Add(Log.Info(message))
+            let p = s.Log.Add(Log.Info(message, callerMemberName, callerFilePath, callerLineNumber))
             from x in put(s.With(Log: p.Log))
             from y in writeToLogStream(p.Added)
             select unit;
@@ -1033,9 +1042,13 @@ namespace Isotope80
         /// <summary>
         /// Log some output as a warning
         /// </summary>
-        public static Isotope<Unit> warn(string message) =>
+        public static Isotope<Unit> warn(
+            string message,
+            [CallerMemberName] string callerMemberName = "", 
+            [CallerFilePath] string callerFilePath = "", 
+            [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = s.Log.Add(Log.Warning(message))
+            let p = s.Log.Add(Log.Warning(message, callerMemberName, callerFilePath, callerLineNumber))
             from x in put(s.With(Log: p.Log))
             from y in writeToLogStream(p.Added)
             select unit;
@@ -1045,9 +1058,13 @@ namespace Isotope80
         /// </summary>
         /// <remarks>Note: This only logs the error, it doesn't stop the computation.  Use `fail` for computation
         /// termination.  `fail` also logs to the output using this function.</remarks>
-        public static Isotope<Unit> error(string message) =>
+        public static Isotope<Unit> error(
+            string message,
+            [CallerMemberName] string callerMemberName = "", 
+            [CallerFilePath] string callerFilePath = "", 
+            [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = s.Log.Add(Log.Error(message))
+            let p = s.Log.Add(Log.Error(message, callerMemberName, callerFilePath, callerLineNumber))
             from x in put(s.With(Log: p.Log))
             from y in writeToLogStream(p.Added)
             select unit;
@@ -1055,9 +1072,14 @@ namespace Isotope80
         /// <summary>
         /// Create a logging context
         /// </summary>
-        public static Isotope<A> context<A>(string context, Isotope<A> iso) =>
+        public static Isotope<A> context<A>(
+            string context,
+            Isotope<A> iso,
+            [CallerMemberName] string callerMemberName = "", 
+            [CallerFilePath] string callerFilePath = "", 
+            [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = Log.Context(context).Rebase(s.Log.Indent)
+            let p = Log.Context(context, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
             from y in writeToLogStream(p)
             from x in put(s.With(Log: p, Context: s.Context.Push(context)))
             from r in iso
@@ -1068,9 +1090,14 @@ namespace Isotope80
         /// <summary>
         /// Create a logging context
         /// </summary>
-        public static Isotope<Env, A> context<Env, A>(string context, Isotope<Env, A> iso) =>
+        public static Isotope<Env, A> context<Env, A>(
+            string context,
+            Isotope<Env, A> iso,
+            [CallerMemberName] string callerMemberName = "", 
+            [CallerFilePath] string callerFilePath = "", 
+            [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = Log.Context(context).Rebase(s.Log.Indent)
+            let p = Log.Context(context, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
             from y in writeToLogStream(p)
             from x in put(s.With(Log: p, Context: s.Context.Push(context)))
             from r in iso
@@ -1081,9 +1108,14 @@ namespace Isotope80
         /// <summary>
         /// Create a logging context
         /// </summary>
-        public static IsotopeAsync<A> context<A>(string context, IsotopeAsync<A> iso) =>
+        public static IsotopeAsync<A> context<A>(
+            string context,
+            IsotopeAsync<A> iso,
+            [CallerMemberName] string callerMemberName = "", 
+            [CallerFilePath] string callerFilePath = "", 
+            [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = Log.Context(context).Rebase(s.Log.Indent)
+            let p = Log.Context(context, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
             from y in writeToLogStream(p)
             from x in put(s.With(Log: p, Context: s.Context.Push(context)))
             from r in iso
@@ -1094,9 +1126,14 @@ namespace Isotope80
         /// <summary>
         /// Create a logging context
         /// </summary>
-        public static IsotopeAsync<Env, A> context<Env, A>(string context, IsotopeAsync<Env, A> iso) =>
+        public static IsotopeAsync<Env, A> context<Env, A>(
+            string context, 
+            IsotopeAsync<Env, A> iso,
+            [CallerMemberName] string callerMemberName = "", 
+            [CallerFilePath] string callerFilePath = "", 
+            [CallerLineNumber] int callerLineNumber = 0) =>
             from s in get
-            let p = Log.Context(context).Rebase(s.Log.Indent)
+            let p = Log.Context(context, callerMemberName, callerFilePath, callerLineNumber).Rebase(s.Log.Indent)
             from y in writeToLogStream(p)
             from x in put(s.With(Log: p, Context: s.Context.Push(context)))
             from r in iso
@@ -1108,7 +1145,7 @@ namespace Isotope80
             new Isotope<Unit>(s => {
                   if (!String.IsNullOrWhiteSpace(entry.Message))
                   {
-                      s.Settings.LogStream.OnNext(new LogOutput(Text.Tabs(s.Context.Count, entry.Message), entry.Type, entry.Indent));
+                      s.Settings.LogStream.OnNext(new LogOutput(entry.Message, entry.Type, s.Context.Count, entry.CallerMemberName, entry.CallerFilePath, entry.CallerLineNumber));
                   }
                   return new IsotopeState<Unit>(default, s);
               });

--- a/src/Isotope80/Log.cs
+++ b/src/Isotope80/Log.cs
@@ -38,7 +38,7 @@ namespace Isotope80
         /// <summary>
         /// Empty log
         /// </summary>
-        public static readonly Log Empty = new Log(0, default, "", default, "", "", 0);
+        public static readonly Log Empty = new Log(0, default, "", default, DateTime.MinValue, "", "", 0);
         
         /// <summary>
         /// Number of tabs to indent
@@ -59,6 +59,11 @@ namespace Isotope80
         /// Child messages
         /// </summary>
         public readonly Seq<Log> Children;
+
+        /// <summary>
+        /// The time the log was captured.
+        /// </summary>
+        public readonly DateTime Time;
         
         /// <summary>
         /// The name of the method the log was called from.
@@ -78,12 +83,13 @@ namespace Isotope80
         /// <summary>
         /// Ctor
         /// </summary>
-        internal Log(int indent, LogType type, string message, Seq<Log> children, string callerMemberName, string callerFilePath, int callerLineNumber)
+        internal Log(int indent, LogType type, string message, Seq<Log> children, DateTime time, string callerMemberName, string callerFilePath, int callerLineNumber)
         {
             Indent           = indent >= 0 ? indent : throw new ArgumentOutOfRangeException(nameof(indent));
             Type             = type;
             Message          = message ?? throw new ArgumentNullException(nameof(message));
             Children         = children;
+            Time             = time;
             CallerMemberName = callerMemberName;
             CallerFilePath   = callerFilePath;
             CallerLineNumber = callerLineNumber;
@@ -95,7 +101,7 @@ namespace Isotope80
         public (Log Log, Log Added) Add(Log log)
         {
             var nlog = log.Type == LogType.Context ? log.Rebase(Indent + 1) : log.Rebase(Indent);
-            return (new Log(Indent, Type, Message, Children.Add(nlog), CallerMemberName, CallerFilePath, CallerLineNumber), nlog);
+            return (new Log(Indent, Type, Message, Children.Add(nlog), Time, CallerMemberName, CallerFilePath, CallerLineNumber), nlog);
         }
 
         /// <summary>
@@ -104,35 +110,35 @@ namespace Isotope80
         /// <param name="indent">Base indent</param>
         /// <returns>Rebased log</returns>
         public Log Rebase(int indent) =>
-            new Log(indent, Type, Message, Children.Map(c => c.Rebase(indent + 1)), CallerMemberName, CallerFilePath, CallerLineNumber);
+            new Log(indent, Type, Message, Children.Map(c => c.Rebase(indent + 1)), Time, CallerMemberName, CallerFilePath, CallerLineNumber);
 
         /// <summary>
         /// Add a message to the log
         /// </summary>
         /// <param name="ctx">Context</param>
-        public static Log Context(string ctx, string callerMemberName, string callerFilePath, int callerLineNumber) =>
-            new Log(0, LogType.Info, ctx, default, callerMemberName, callerFilePath, callerLineNumber);
+        public static Log Context(string ctx, DateTime time, string callerMemberName, string callerFilePath, int callerLineNumber) =>
+            new Log(0, LogType.Info, ctx, default, time, callerMemberName, callerFilePath, callerLineNumber);
 
         /// <summary>
         /// Add a message to the log
         /// </summary>
         /// <param name="message">Message to log</param>
-        public static Log Info(string message, string callerMemberName, string callerFilePath, int callerLineNumber) =>
-            new Log(0, LogType.Info, $"INFO: {message}", default, callerMemberName, callerFilePath, callerLineNumber); 
+        public static Log Info(string message, DateTime time, string callerMemberName, string callerFilePath, int callerLineNumber) =>
+            new Log(0, LogType.Info, $"INFO: {message}", default, time, callerMemberName, callerFilePath, callerLineNumber); 
 
         /// <summary>
         /// Add a message to the log
         /// </summary>
         /// <param name="message">Message to log</param>
-        public static Log Warning(string message, string callerMemberName, string callerFilePath, int callerLineNumber) =>
-            new Log(0, LogType.Warn, $"WARN: {message}", default, callerMemberName, callerFilePath, callerLineNumber);
+        public static Log Warning(string message, DateTime time, string callerMemberName, string callerFilePath, int callerLineNumber) =>
+            new Log(0, LogType.Warn, $"WARN: {message}", default, time, callerMemberName, callerFilePath, callerLineNumber);
 
         /// <summary>
         /// Add a message to the log
         /// </summary>
         /// <param name="message">Message to log</param>
-        public static Log Error(string message, string callerMemberName, string callerFilePath, int callerLineNumber) =>
-            new Log(0, LogType.Error, $"ERRO: {message}", default, callerMemberName, callerFilePath, callerLineNumber);
+        public static Log Error(string message, DateTime time, string callerMemberName, string callerFilePath, int callerLineNumber) =>
+            new Log(0, LogType.Error, $"ERRO: {message}", default, time, callerMemberName, callerFilePath, callerLineNumber);
 
         /// <summary>
         /// ToString
@@ -174,6 +180,11 @@ namespace Isotope80
         /// Indentation
         /// </summary>
         public readonly int Indent;
+
+        /// <summary>
+        /// The time the log was captured.
+        /// </summary>
+        public readonly DateTime Time;
         
         /// <summary>
         /// The name of the method the log was called from.
@@ -193,11 +204,12 @@ namespace Isotope80
         /// <summary>
         /// Ctor
         /// </summary>
-        public LogOutput(string message, LogType type, int indent, string callerMemberName, string callerFilePath, int callerLineNumber)
+        public LogOutput(string message, LogType type, int indent, DateTime time, string callerMemberName, string callerFilePath, int callerLineNumber)
         {
             Message          = message ?? throw new ArgumentNullException(nameof(message));
             Type             = type;
             Indent           = indent >= 0 ? indent : throw new ArgumentOutOfRangeException(nameof(indent));
+            Time             = time;
             CallerMemberName = callerMemberName;
             CallerFilePath   = callerFilePath;
             CallerLineNumber = callerLineNumber;
@@ -210,9 +222,14 @@ namespace Isotope80
             Text.Tabs(Indent, Message);
 
         /// <summary>
-        /// Tabbed format display including the file path and lines
+        /// Tabbed format display including the file path, line number and time.
         /// </summary>
-        public string ToStringWithPath() =>
-            Text.Tabs(Indent, $"{Message}        {"".PadRight(Math.Max(0, 60 - Message.Length - Text.Tabs(Indent).Length), ' ')}{CallerFilePath}:line {CallerLineNumber}");
+        /// <param name="expectedMaxMessageLength">Number of characters reserved for the message so the output looks lined up.</param>
+        /// <remarks>
+        /// Message format: [TIME]: [INDENT][MESSAGE][GAP][FILE]:line [LINE] 
+        /// </remarks>
+        public string ToVerboseString(int expectedMaxMessageLength = 60) =>
+            Time.ToString("HH:mm:ss.fff: ") +
+            Text.Tabs(Indent, $"{Message}        {"".PadRight(Math.Max(0, expectedMaxMessageLength - Message.Length - Text.Tabs(Indent).Length), ' ')}{CallerFilePath}:line {CallerLineNumber}");
     }
 }


### PR DESCRIPTION
The logging (context/log/info/warm/error) captures also the caller method/file/line. `ToStringWithPath` added to get formated lines into the output.

`writeToLogStream` fixed - it does not format the message anymore, it properly creats `LogOutput` with the correct Indent (previously it was 0 all the time)