### PR TITLE
Surface additional browser controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Isotope allows statements to be composed together, you can do this using the Bin
 
 ```cs
 var logic =  nav("https://twitter.com/login")
-              .Bind(x => className("js-username-field"), "Your Email Address"));
+              .Bind(x => sendKeys(className("js-username-field"), "Your Email Address"));
 ```
 
 However the recommended method is to use C#'s LINQ syntax:

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -563,6 +563,74 @@ namespace Isotope80
             select unit;
 
         /// <summary>
+        /// Navigate back using the browser's back button
+        /// </summary>
+        public static Isotope<Unit> back =>
+            from d in webDriver
+            from _ in trya(() => d.Navigate().Back(), "Failed to go back in browser")
+            select unit;
+
+        /// <summary>
+        /// Navigate forward using the browser's forward button
+        /// </summary>
+        public static Isotope<Unit> forward =>
+            from d in webDriver
+            from _ in trya(() => d.Navigate().Forward(), "Failed to go forward in browser")
+            select unit;
+
+        /// <summary>
+        /// Refresh current page
+        /// </summary>
+        public static Isotope<Unit> refresh =>
+            from d in webDriver
+            from _ in trya(() => d.Navigate().Refresh(), "Failed to refresh current page")
+            select unit;
+
+        /// <summary>
+        /// Opens and switches to new tab
+        /// </summary>
+        public static Isotope<Unit> newTab =>
+            from d in webDriver
+            from _ in trya(() => d.SwitchTo().NewWindow(WindowType.Tab), "Failed to open new tab")
+            select unit;
+
+        /// <summary>
+        /// Opens and switches to new tab, then executes Isotope
+        /// </summary>
+        public static Isotope<T> NewTab<T>(this Isotope<T> iso) =>
+            from _1 in newTab
+            from i in iso
+            select i;
+
+        /// <summary>
+        /// Change browser tab by position, determined by the order opened <para/>
+        /// Tabs in separate window also switchable to in the same order
+        /// </summary>
+        /// <param name="position">Zero-based position of tab</param>
+        /// <returns></returns>
+        public static Isotope<Unit> switchTabs(int position) =>
+            from d in webDriver
+            let tabs = d.WindowHandles
+            from _ in trya(() => d.SwitchTo().Window(tabs[position]), "Failed to switch tabs")
+            select unit;
+
+        /// <summary>
+        /// Opens and switches to new window
+        /// </summary>
+        public static Isotope<Unit> newWindow =>
+            from d in webDriver
+            from _ in trya(() => d.SwitchTo().NewWindow(WindowType.Window), "Failed to open new window")
+            select unit;
+
+        /// <summary>
+        /// Opens and switched to new window, then executes Isotope
+        /// </summary>
+        public static Isotope<T> NewWindow<T>(this Isotope<T> iso) =>
+            from _1 in newWindow
+            from i in iso
+            select i;
+
+        /// <summary>
         /// Navigate to a URL
         /// </summary>
         /// <param name="url">URL to navigate to</param>

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -595,14 +595,6 @@ namespace Isotope80
             select unit;
 
         /// <summary>
-        /// Opens and switches to new tab, then executes Isotope
-        /// </summary>
-        public static Isotope<T> NewTab<T>(this Isotope<T> iso) =>
-            from _1 in newTab
-            from i in iso
-            select i;
-
-        /// <summary>
         /// Change browser tab by position, determined by the order opened <para/>
         /// Tabs in separate window also switchable to in the same order
         /// </summary>
@@ -611,7 +603,7 @@ namespace Isotope80
         public static Isotope<Unit> switchTabs(int position) =>
             from d in webDriver
             let tabs = d.WindowHandles
-            from _ in trya(() => d.SwitchTo().Window(tabs[position]), "Failed to switch tabs")
+            from _ in trya(() => d.SwitchTo().Window(tabs[position]), $"Failed to switch to tab {position}")
             select unit;
 
         /// <summary>
@@ -621,14 +613,6 @@ namespace Isotope80
             from d in webDriver
             from _ in trya(() => d.SwitchTo().NewWindow(WindowType.Window), "Failed to open new window")
             select unit;
-
-        /// <summary>
-        /// Opens and switched to new window, then executes Isotope
-        /// </summary>
-        public static Isotope<T> NewWindow<T>(this Isotope<T> iso) =>
-            from _1 in newWindow
-            from i in iso
-            select i;
 
         /// <summary>
         /// Navigate to a URL


### PR DESCRIPTION
Surfacing of the new window and new tab methods added with Selenium 4. I think there is a use for these simply as `newTab` with actions to follow, and as extension methods such as `nav("https://meddbase.com").NewTab()`. 

To accommodate the addition of being able to add a new window or tab in the same session, this also adds a `switchTabs` method. Browser tabs do have identifiers that can be used, but making use of this for navigating to a specific tab would involve getting the `CurrentWindowHandle` throughout, which doesn't seem to make use much easier than using the tab position/opened order as is done here.  

Also surfaces some more browser navigation controls; back, forward and refresh.