### PR TITLE
Overwrite function

### DIFF
--- a/src/Isotope80/Internal/IsotopeInternal.cs
+++ b/src/Isotope80/Internal/IsotopeInternal.cs
@@ -12,6 +12,7 @@ using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Edge;
 using OpenQA.Selenium.Firefox;
 using OpenQA.Selenium.IE;
+using OpenQA.Selenium.Interactions;
 using static LanguageExt.Prelude;
 using static Isotope80.Isotope;
 
@@ -135,6 +136,25 @@ namespace Isotope80
         /// <returns>Unit</returns>
         public static Isotope<Unit> clear(IWebElement element) =>
             trya(element.Clear, $@"Error clearing element: {prettyPrint(element)}");
+        
+        /// <summary>
+        /// Overwrites the content of an element
+        /// </summary>
+        /// <param name="element">Web Driver Element</param>
+        /// <param name="keys">String of characters that are typed</param>
+        /// <returns>Unit</returns>
+        public static Isotope<Unit> overwrite(IWebElement element, string keys) =>
+            from dvr in webDriver
+            let actions = new Actions(dvr)
+            from _1 in trya(() => actions.Click(element)
+                                         .SendKeys(Keys.End)
+                                         .KeyDown(Keys.Shift)
+                                         .SendKeys(Keys.Home)
+                                         .KeyUp(Keys.Shift)
+                                         .SendKeys(Keys.Backspace)
+                                         .SendKeys(keys)
+                                         .Perform(), $@"Error overwriting element: {prettyPrint(element)}")
+            select unit;
         
         public static string prettyPrint(IWebElement x)
         {

--- a/src/Isotope80/Internal/IsotopeInternal.cs
+++ b/src/Isotope80/Internal/IsotopeInternal.cs
@@ -147,10 +147,9 @@ namespace Isotope80
             from dvr in webDriver
             let actions = new Actions(dvr)
             from _1 in trya(() => actions.Click(element)
-                                         .SendKeys(Keys.End)
-                                         .KeyDown(Keys.Shift)
-                                         .SendKeys(Keys.Home)
-                                         .KeyUp(Keys.Shift)
+                                         .KeyDown(Keys.Control)
+                                         .SendKeys("a")
+                                         .KeyUp(Keys.Control)
                                          .SendKeys(Keys.Backspace)
                                          .SendKeys(keys)
                                          .Perform(), $@"Error overwriting element: {prettyPrint(element)}")

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -829,6 +829,15 @@ namespace Isotope80
                     .Bind(IsotopeInternal.clear);
 
         /// <summary>
+        /// Simulates keyboard by sending `keys` and overwriting current content 
+        /// </summary>
+        /// <param name="selector">Web element selector</param>
+        /// <param name="keys">String of characters that are typed</param>
+        public static Isotope<Unit> overwrite(Select selector, string keys) =>
+            selector.ToIsotopeHead()
+                    .Bind(el => IsotopeInternal.overwrite(el, keys));
+        
+        /// <summary>
         /// ONLY USE AS A LAST RESORT
         /// Pauses the processing for an interval to brute force waiting for actions to complete
         /// </summary>

--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -829,10 +829,16 @@ namespace Isotope80
                     .Bind(IsotopeInternal.clear);
 
         /// <summary>
-        /// Simulates keyboard by sending `keys` and overwriting current content 
+        /// Simulates keyboard by sending `keys` and overwriting current content
         /// </summary>
         /// <param name="selector">Web element selector</param>
         /// <param name="keys">String of characters that are typed</param>
+        /// <remarks>
+        /// Series of actions where element is clicked, pressed keys CTRL+A, Backspace then typed in new keys.
+        /// It is an alternative to clear (without triggering event (change, blur or focus)) and sendKeys
+        /// 
+        /// https://stackoverflow.com/questions/19833728/webelement-clear-fires-javascript-change-event-alternatives
+        /// </remarks>
         public static Isotope<Unit> overwrite(Select selector, string keys) =>
             selector.ToIsotopeHead()
                     .Bind(el => IsotopeInternal.overwrite(el, keys));


### PR DESCRIPTION
When we were trying to overwrite value in some field, we used clear() and sendKeys() methods. There is a known problem with clear() method, which triggers OnBlur / OnChange event, and this sometimes causes error dialog popping up.
This will solve the issue.