### PR TITLE
Selenium paket bump

### DIFF
--- a/samples/Samples.Console/Samples.Console.csproj
+++ b/samples/Samples.Console/Samples.Console.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="LanguageExt.Core" Version="4.4.3" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="114.0.5735.9000" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 

--- a/samples/Samples.UnitTests/Samples.UnitTests.csproj
+++ b/samples/Samples.UnitTests/Samples.UnitTests.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="114.0.5735.9000" />
     <PackageReference Include="XUnit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Isotope80/Isotope80.csproj
+++ b/src/Isotope80/Isotope80.csproj
@@ -23,8 +23,8 @@
   <ItemGroup>
 	  <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
 	  <PackageReference Include="LanguageExt.Core" Version="4.4.3" />
-      <PackageReference Include="Selenium.Support" Version="4.0.0" />
-      <PackageReference Include="Selenium.WebDriver" Version="4.0.0" />
+      <PackageReference Include="Selenium.Support" Version="4.11.0" />
+      <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
       <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Selenium updated to version 4.11.0.
Chrome driver package has been removed, as the new selenium takes care of the correct version of driver.
https://www.selenium.dev/blog/2023/whats-new-in-selenium-manager-with-selenium-4.11.0/

