### PR TITLE
Added keepAlive overloads for withWebDriver to support persistent dri…

### DIFF
--- a/src/Isotope80/Isotope.cs
+++ b/src/Isotope80/Isotope.cs
@@ -248,20 +248,48 @@ namespace Isotope80
         /// </summary>
         public static Isotope<A> withWebDriver<A>(IWebDriver driver, Isotope<A> ma) =>
             use(driver, disposeWebDriver, d => from st in get
-                                               from _1 in setWebDriver(driver)  
+                                               from _1 in setWebDriver(driver)
                                                from rs in ma
-                                               from _2 in st.Driver.Match(Some: setWebDriver, None: clearWebDriver) 
+                                               from _2 in st.Driver.Match(Some: setWebDriver, None: clearWebDriver)
                                                select rs);
+
+        /// <summary>
+        /// Run the isotope provided with the web-driver context.
+        /// When <paramref name="keepAlive"/> is true the driver is not disposed after the isotope completes,
+        /// allowing the same driver to be reused across multiple runs (e.g. REPL / persistent sessions).
+        /// </summary>
+        public static Isotope<A> withWebDriver<A>(IWebDriver driver, Isotope<A> ma, bool keepAlive) =>
+            keepAlive
+                ? from st in get
+                  from _1 in setWebDriver(driver)
+                  from rs in ma
+                  from _2 in st.Driver.Match(Some: setWebDriver, None: clearWebDriver)
+                  select rs
+                : withWebDriver(driver, ma);
 
         /// <summary>
         /// Run the isotope provided with the web-driver context
         /// </summary>
         public static Isotope<Env, A> withWebDriver<Env, A>(IWebDriver driver, Isotope<Env, A> ma) =>
             use(driver, disposeWebDriver, d => from st in get
-                                               from _1 in setWebDriver(driver)  
+                                               from _1 in setWebDriver(driver)
                                                from rs in ma
-                                               from _2 in st.Driver.Match(Some: setWebDriver, None: clearWebDriver) 
+                                               from _2 in st.Driver.Match(Some: setWebDriver, None: clearWebDriver)
                                                select rs);
+
+        /// <summary>
+        /// Run the isotope provided with the web-driver context.
+        /// When <paramref name="keepAlive"/> is true the driver is not disposed after the isotope completes,
+        /// allowing the same driver to be reused across multiple runs (e.g. REPL / persistent sessions).
+        /// </summary>
+        public static Isotope<Env, A> withWebDriver<Env, A>(IWebDriver driver, Isotope<Env, A> ma, bool keepAlive) =>
+            keepAlive
+                ? from st in get
+                  from _1 in setWebDriver(driver)
+                  from rs in ma
+                  from _2 in st.Driver.Match(Some: setWebDriver, None: clearWebDriver)
+                  select rs
+                : withWebDriver(driver, ma);
 
         /// <summary>
         /// Run the isotope provided with the web-driver context


### PR DESCRIPTION
…ver sessions

Added new overloads of withWebDriver for both Isotope<A> and Isotope<Env, A> that accept a bool keepAlive parameter. When keepAlive is true the web driver is not disposed after the isotope completes, allowing the same driver instance to be reused across multiple runs. This is useful for REPL workflows and persistent sessions where spinning up a new browser for each run is undesirable.

When keepAlive is false the new overloads delegate to the existing withWebDriver methods which wrap the driver in a use block and dispose it on completion, preserving the current default behaviour.