### PR TITLE
Sequence discarded all state changes except Log

### DIFF
--- a/samples/Samples.Playwright.UnitTests/WindowAndTabTests.cs
+++ b/samples/Samples.Playwright.UnitTests/WindowAndTabTests.cs
@@ -98,7 +98,7 @@ public class WindowAndTabTests
                 info("before switch"),
                 switchTabs(1),
                 info("after switch")
-            ).Sequence().Select(_ => unit)
+            ).Sequence().Map(_ => unit)
             from tabAfter in getCurrentTabNumber
             from _7 in assert(tabAfter == 1, $"Expected tab 1 after Sequence, got {tabAfter}")
             select unit;

--- a/samples/Samples.Playwright.UnitTests/WindowAndTabTests.cs
+++ b/samples/Samples.Playwright.UnitTests/WindowAndTabTests.cs
@@ -85,6 +85,28 @@ public class WindowAndTabTests
     }
 
     [Fact]
+    public async Task Sequence_preserves_tab_switch()
+    {
+        var test =
+            from _1 in nav("data:text/html,<html><body><h1>Tab 0</h1></body></html>")
+            from _2 in newTab
+            from _3 in nav("data:text/html,<html><body><h1>Tab 1</h1></body></html>")
+            from _4 in switchTabs(0)
+            from tabBefore in getCurrentTabNumber
+            from _5 in assert(tabBefore == 0, $"Expected tab 0 before Sequence, got {tabBefore}")
+            from _6 in Seq(
+                info("before switch"),
+                switchTabs(1),
+                info("after switch")
+            ).Sequence().Select(_ => unit)
+            from tabAfter in getCurrentTabNumber
+            from _7 in assert(tabAfter == 1, $"Expected tab 1 after Sequence, got {tabAfter}")
+            select unit;
+
+        await withChromium(test).RunAndThrowOnError();
+    }
+
+    [Fact]
     public async Task NewWindow_creates_isolated_context()
     {
         var test =

--- a/samples/Samples.UnitTests/WindowAndTabTests.cs
+++ b/samples/Samples.UnitTests/WindowAndTabTests.cs
@@ -1,0 +1,47 @@
+using System;
+using LanguageExt;
+using Xunit;
+using Xunit.Abstractions;
+using Isotope80;
+using static LanguageExt.Prelude;
+using static Isotope80.Isotope;
+using static Isotope80.Assertions;
+
+namespace Samples.UnitTests
+{
+    public class WindowAndTabTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public WindowAndTabTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void Sequence_preserves_tab_switch()
+        {
+            var stgs = IsotopeSettings.Create();
+            stgs.LogStream.Subscribe(x => output.WriteLine(x.ToString()));
+            stgs.ErrorStream.Subscribe(x => output.WriteLine(x.ToString()));
+
+            var iso =
+                from _1 in nav("data:text/html,<html><body><h1>Tab 0</h1></body></html>")
+                from _2 in newTab
+                from _3 in nav("data:text/html,<html><body><h1>Tab 1</h1></body></html>")
+                from _4 in switchTabs(0)
+                from tabBefore in getCurrentTabNumber
+                from _5 in assert(tabBefore == 0, $"Expected tab 0 before Sequence, got {tabBefore}")
+                from _6 in Seq(
+                    info("before switch"),
+                    switchTabs(1),
+                    info("after switch")
+                ).Sequence().Map(_ => unit)
+                from tabAfter in getCurrentTabNumber
+                from _7 in assert(tabAfter == 1, $"Expected tab 1 after Sequence, got {tabAfter}")
+                select unit;
+
+            (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: stgs);
+        }
+    }
+}

--- a/src/Isotope80.Shared/Isotope.Shared.cs
+++ b/src/Isotope80.Shared/Isotope.Shared.cs
@@ -794,7 +794,7 @@ namespace Isotope80
                         index++;
                     }
 
-                    return new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log));
+                    return new IsotopeState<Seq<A>>(vals.ToSeq(), nstate);
                 });
 
         /// <summary>
@@ -837,7 +837,7 @@ namespace Isotope80
                         index++;
                     }
 
-                    return new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log));
+                    return new IsotopeState<Seq<A>>(vals.ToSeq(), nstate);
                 });
 
         /// <summary>
@@ -880,7 +880,7 @@ namespace Isotope80
                         index++;
                     }
 
-                    return new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log));
+                    return new IsotopeState<Seq<A>>(vals.ToSeq(), nstate);
                 });
 
         /// <summary>
@@ -923,7 +923,7 @@ namespace Isotope80
                         index++;
                     }
 
-                    return new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log));
+                    return new IsotopeState<Seq<A>>(vals.ToSeq(), nstate);
                 });
 
         /// <summary>

--- a/src/Isotope80.Shared/Isotope.Shared.cs
+++ b/src/Isotope80.Shared/Isotope.Shared.cs
@@ -786,7 +786,7 @@ namespace Isotope80
                         {
                             return new IsotopeState<Seq<A>>(
                                 vals.ToSeq(),
-                                state.With(Error: rstate.State.Error, Log: rstate.State.Log));
+                                nstate.With(Error: rstate.State.Error, Log: rstate.State.Log));
                         }
 
                         nstate      = rstate.State;
@@ -817,7 +817,6 @@ namespace Isotope80
             new Isotope<Env, Seq<A>>(
                 (env, state) => {
                     var vals  = new A[mas.Count];
-                    var log   = state.Log;
                     int index = 0;
 
                     var nstate = state;
@@ -829,7 +828,7 @@ namespace Isotope80
                         {
                             return new IsotopeState<Seq<A>>(
                                 vals.ToSeq(),
-                                state.With(Error: rstate.State.Error, Log: rstate.State.Log));
+                                nstate.With(Error: rstate.State.Error, Log: rstate.State.Log));
                         }
 
                         nstate      = rstate.State;
@@ -860,7 +859,6 @@ namespace Isotope80
             new IsotopeAsync<Seq<A>>(
                 async state => {
                     var vals  = new A[mas.Count];
-                    var log   = state.Log;
                     int index = 0;
 
                     var nstate = state;
@@ -872,7 +870,7 @@ namespace Isotope80
                         {
                             return new IsotopeState<Seq<A>>(
                                 vals.ToSeq(),
-                                state.With(Error: rstate.State.Error, Log: rstate.State.Log));
+                                nstate.With(Error: rstate.State.Error, Log: rstate.State.Log));
                         }
 
                         nstate      = rstate.State;
@@ -903,7 +901,6 @@ namespace Isotope80
             new IsotopeAsync<Env, Seq<A>>(
                 async (env, state) => {
                     var vals  = new A[mas.Count];
-                    var log   = state.Log;
                     int index = 0;
 
                     var nstate = state;
@@ -915,7 +912,7 @@ namespace Isotope80
                         {
                             return new IsotopeState<Seq<A>>(
                                 vals.ToSeq(),
-                                state.With(Error: rstate.State.Error, Log: rstate.State.Log));
+                                nstate.With(Error: rstate.State.Error, Log: rstate.State.Log));
                         }
 
                         nstate      = rstate.State;
@@ -955,7 +952,7 @@ namespace Isotope80
 
                         vals[index] = rstate.Value;
                         errs[index] = rstate.State.Error;
-                        nstate = state.With(Error: Empty, Log: rstate.State.Log);
+                        nstate      = rstate.State.With(Error: Empty);
 
                         index++;
                     }
@@ -964,8 +961,8 @@ namespace Isotope80
                     var nerr = errs.Fold(Seq<Error>(), (s, e) => s + e);
 
                     return nerr.IsEmpty
-                               ? new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log))
-                               : new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Error: nerr, Log: nstate.Log));
+                               ? new IsotopeState<Seq<A>>(vals.ToSeq(), nstate)
+                               : new IsotopeState<Seq<A>>(vals.ToSeq(), nstate.With(Error: nerr));
                 });
 
         /// <summary>
@@ -997,7 +994,7 @@ namespace Isotope80
 
                         vals[index] = rstate.Value;
                         errs[index] = rstate.State.Error;
-                        nstate      = state.With(Error: Empty, Log: rstate.State.Log);
+                        nstate      = rstate.State.With(Error: Empty);
 
                         index++;
                     }
@@ -1006,8 +1003,8 @@ namespace Isotope80
                     var nerr = errs.Fold(Seq<Error>(), (s, e) => s + e);
 
                     return nerr.IsEmpty
-                               ? new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log))
-                               : new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Error: nerr, Log: nstate.Log));
+                               ? new IsotopeState<Seq<A>>(vals.ToSeq(), nstate)
+                               : new IsotopeState<Seq<A>>(vals.ToSeq(), nstate.With(Error: nerr));
                 });
 
         /// <summary>
@@ -1039,7 +1036,7 @@ namespace Isotope80
 
                         vals[index] = rstate.Value;
                         errs[index] = rstate.State.Error;
-                        nstate      = state.With(Error: Empty, Log: rstate.State.Log);
+                        nstate      = rstate.State.With(Error: Empty);
 
                         index++;
                     }
@@ -1048,8 +1045,8 @@ namespace Isotope80
                     var nerr = errs.Fold(Seq<Error>(), (s, e) => s + e);
 
                     return nerr.IsEmpty
-                               ? new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log))
-                               : new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Error: nerr, Log: nstate.Log));
+                               ? new IsotopeState<Seq<A>>(vals.ToSeq(), nstate)
+                               : new IsotopeState<Seq<A>>(vals.ToSeq(), nstate.With(Error: nerr));
                 });
 
         /// <summary>
@@ -1081,7 +1078,7 @@ namespace Isotope80
 
                         vals[index] = rstate.Value;
                         errs[index] = rstate.State.Error;
-                        nstate      = state.With(Error: Empty, Log: rstate.State.Log);
+                        nstate      = rstate.State.With(Error: Empty);
 
                         index++;
                     }
@@ -1090,8 +1087,8 @@ namespace Isotope80
                     var nerr = errs.Fold(Seq<Error>(), (s, e) => s + e);
 
                     return nerr.IsEmpty
-                               ? new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log))
-                               : new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Error: nerr, Log: nstate.Log));
+                               ? new IsotopeState<Seq<A>>(vals.ToSeq(), nstate)
+                               : new IsotopeState<Seq<A>>(vals.ToSeq(), nstate.With(Error: nerr));
                 });
 
         /// <summary>


### PR DESCRIPTION
The original problem was: Switching tabs inside Sequence did not persist because the final return rebuilt state from the original input, discarding accumulated state changes including the active Page. Only Log was carried forward.

Isotope.Shared.cs — all 4 Sequence overloads (Isotope<A>, Isotope<Env, A>, IsotopeAsync<A>, IsotopeAsync<Env, A>) accumulated state correctly through items in the loop (nstate = rstate.State) but on the final return rebuilt from the original state:

return new IsotopeState<Seq<A>>(vals.ToSeq(), state.With(Log: nstate.Log));

This silently discarded all state mutations (e.g. Page, Settings) except Log. With Selenium this was invisible because tab switching mutated a shared WebDriver object — the state reset didn't matter. With Playwright, the active page is tracked in Isotope state via Page, so Sequence discarding it caused switchTabs inside ActionTasks to have no effect.
Fix: Return the accumulated state directly:

return new IsotopeState<Seq<A>>(vals.ToSeq(), nstate);