### PR TITLE
 OnFail preserves state, | resets

### DIFF
--- a/samples/Samples.Playwright.UnitTests/WindowAndTabTests.cs
+++ b/samples/Samples.Playwright.UnitTests/WindowAndTabTests.cs
@@ -120,4 +120,38 @@ public class WindowAndTabTests
 
         await withChromium(test).RunAndThrowOnError();
     }
+
+    [Fact]
+    public async Task OnFail_sees_page_source_from_failed_tab()
+    {
+        var lhs =
+            from _1 in nav("data:text/html,<html><body>Tab A</body></html>")
+            from _2 in newTab
+            from _3 in nav("data:text/html,<html><body>Tab B</body></html>")
+            from _4 in fail<string>("boom")
+            select "";
+
+        var (_, value) = await withChromium(
+                             IsotopeAsync<string>.OnFail(lhs, pageSource)
+                         ).RunAndThrowOnError();
+
+        Assert.Contains("Tab B", value);
+    }
+
+    [Fact]
+    public async Task Pipe_operator_sees_page_source_from_original_tab()
+    {
+        var lhs =
+            from _1 in nav("data:text/html,<html><body>Tab A</body></html>")
+            from _2 in newTab
+            from _3 in nav("data:text/html,<html><body>Tab B</body></html>")
+            from _4 in fail<string>("boom")
+            select "";
+
+        var (_, value) = await withChromium(
+                             lhs | pageSource
+                         ).RunAndThrowOnError();
+
+        Assert.Contains("Tab A", value);
+    }
 }

--- a/samples/Samples.Playwright.UnitTests/WindowAndTabTests.cs
+++ b/samples/Samples.Playwright.UnitTests/WindowAndTabTests.cs
@@ -124,7 +124,7 @@ public class WindowAndTabTests
     [Fact]
     public async Task OnFail_sees_page_source_from_failed_tab()
     {
-        var lhs =
+        var operation =
             from _1 in nav("data:text/html,<html><body>Tab A</body></html>")
             from _2 in newTab
             from _3 in nav("data:text/html,<html><body>Tab B</body></html>")
@@ -132,7 +132,7 @@ public class WindowAndTabTests
             select "";
 
         var (_, value) = await withChromium(
-                             IsotopeAsync<string>.OnFail(lhs, pageSource)
+                             operation.OnFail(pageSource)
                          ).RunAndThrowOnError();
 
         Assert.Contains("Tab B", value);
@@ -141,7 +141,7 @@ public class WindowAndTabTests
     [Fact]
     public async Task Pipe_operator_sees_page_source_from_original_tab()
     {
-        var lhs =
+        var operation =
             from _1 in nav("data:text/html,<html><body>Tab A</body></html>")
             from _2 in newTab
             from _3 in nav("data:text/html,<html><body>Tab B</body></html>")
@@ -149,7 +149,7 @@ public class WindowAndTabTests
             select "";
 
         var (_, value) = await withChromium(
-                             lhs | pageSource
+                             operation | pageSource
                          ).RunAndThrowOnError();
 
         Assert.Contains("Tab A", value);

--- a/samples/Samples.UnitTests/WindowAndTabTests.cs
+++ b/samples/Samples.UnitTests/WindowAndTabTests.cs
@@ -43,34 +43,34 @@ namespace Samples.UnitTests
 
             (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: stgs);
         }
-        
+
         [Fact]
-        public void OnFail_passes_failed_state_to_rhs()
+        public void OnFail_passes_failed_state_to_handler()
         {
-            var lhs = from _1 in initConfig(("marker", "from-lhs"))
-                      from _2 in fail<string>("boom")
-                      select "";
+            var operation = from _1 in initConfig(("marker", "from-operation"))
+                            from _2 in fail<string>("boom")
+                            select "";
 
-            var rhs = config("marker");
+            var handler = config("marker");
 
-            var (state, value) = Isotope<string>.OnFail(lhs, rhs).Run();
+            var (state, value) = operation.OnFail(handler).Run();
 
             Assert.False(state.IsFaulted);
-            Assert.Equal("from-lhs", value);
+            Assert.Equal("from-operation", value);
         }
 
         [Fact]
-        public void Pipe_operator_does_not_pass_failed_state_to_rhs()
+        public void Pipe_operator_does_not_pass_failed_state_to_handler()
         {
-            var lhs = from _1 in initConfig(("marker", "from-lhs"))
-                      from _2 in fail<string>("boom")
-                      select "";
+            var operation = from _1 in initConfig(("marker", "from-operation"))
+                            from _2 in fail<string>("boom")
+                            select "";
 
-            var rhs = config("marker");
+            var handler = config("marker");
 
-            var (state, _) = (lhs | rhs).Run();
+            var (state, _) = (operation | handler).Run();
 
-            Assert.True(state.IsFaulted, "Expected rhs to fail because | passes original state");
+            Assert.True(state.IsFaulted, "Expected handler to fail because | passes original state");
         }
     }
 }

--- a/samples/Samples.UnitTests/WindowAndTabTests.cs
+++ b/samples/Samples.UnitTests/WindowAndTabTests.cs
@@ -43,5 +43,34 @@ namespace Samples.UnitTests
 
             (var state, var value) = withChromeDriver(iso).RunAndThrowOnError(settings: stgs);
         }
+        
+        [Fact]
+        public void OnFail_passes_failed_state_to_rhs()
+        {
+            var lhs = from _1 in initConfig(("marker", "from-lhs"))
+                      from _2 in fail<string>("boom")
+                      select "";
+
+            var rhs = config("marker");
+
+            var (state, value) = Isotope<string>.OnFail(lhs, rhs).Run();
+
+            Assert.False(state.IsFaulted);
+            Assert.Equal("from-lhs", value);
+        }
+
+        [Fact]
+        public void Pipe_operator_does_not_pass_failed_state_to_rhs()
+        {
+            var lhs = from _1 in initConfig(("marker", "from-lhs"))
+                      from _2 in fail<string>("boom")
+                      select "";
+
+            var rhs = config("marker");
+
+            var (state, _) = (lhs | rhs).Run();
+
+            Assert.True(state.IsFaulted, "Expected rhs to fail because | passes original state");
+        }
     }
 }

--- a/src/Isotope80.Shared/Isotope.Shared.cs
+++ b/src/Isotope80.Shared/Isotope.Shared.cs
@@ -112,6 +112,34 @@ namespace Isotope80
             select r;
 
         /// <summary>
+        /// Run the operation, if it fails run the handler with the failed state (preserving Page, BrowserContext, etc.)
+        /// Unlike | which resets to the original state for retry semantics.
+        /// </summary>
+        public static Isotope<A> onFail<A>(Isotope<A> operation, Isotope<A> handler) =>
+            operation.OnFail(handler);
+
+        /// <summary>
+        /// Run the operation, if it fails run the handler with the failed state (preserving Page, BrowserContext, etc.)
+        /// Unlike | which resets to the original state for retry semantics.
+        /// </summary>
+        public static IsotopeAsync<A> onFail<A>(IsotopeAsync<A> operation, IsotopeAsync<A> handler) =>
+            operation.OnFail(handler);
+
+        /// <summary>
+        /// Run the operation, if it fails run the handler with the failed state (preserving Page, BrowserContext, etc.)
+        /// Unlike | which resets to the original state for retry semantics.
+        /// </summary>
+        public static Isotope<Env, A> onFail<Env, A>(Isotope<Env, A> operation, Isotope<Env, A> handler) =>
+            operation.OnFail(handler);
+
+        /// <summary>
+        /// Run the operation, if it fails run the handler with the failed state (preserving Page, BrowserContext, etc.)
+        /// Unlike | which resets to the original state for retry semantics.
+        /// </summary>
+        public static IsotopeAsync<Env, A> onFail<Env, A>(IsotopeAsync<Env, A> operation, IsotopeAsync<Env, A> handler) =>
+            operation.OnFail(handler);
+
+        /// <summary>
         /// Lift the function into the isotope monadic space
         /// </summary>
         public static Isotope<A> iso<A>(Func<A> f) =>

--- a/src/Isotope80.Shared/IsotopeAsync_A.cs
+++ b/src/Isotope80.Shared/IsotopeAsync_A.cs
@@ -97,20 +97,23 @@ namespace Isotope80
             });
 
         /// <summary>
-        /// Run lhs, if it fails run rhs with the failed state (preserving Page, BrowserContext, etc.)
+        /// Run the operation, if it fails run the handler with the failed state (preserving Page, BrowserContext, etc.)
         /// Unlike | which resets to the original state for retry semantics.
         /// </summary>
-        public static IsotopeAsync<A> OnFail(IsotopeAsync<A> lhs, IsotopeAsync<A> rhs) =>
-            new IsotopeAsync<A>(async s =>
+        public IsotopeAsync<A> OnFail(IsotopeAsync<A> handler)
+        {
+            var operation = this;
+            return new IsotopeAsync<A>(async s =>
             {
-                var l = await lhs.Invoke(s).ConfigureAwait(false);
+                var l = await operation.Invoke(s).ConfigureAwait(false);
                 if (!l.IsFaulted) return l;
 
-                var r = await rhs.Invoke(l.State.With(Error: default(Seq<Error>))).ConfigureAwait(false);
+                var r = await handler.Invoke(l.State.With(Error: default(Seq<Error>))).ConfigureAwait(false);
                 return r.IsFaulted
-                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           ? new IsotopeState<A>(default, l.State.With(Error: l.State.Error + r.State.Error))
                            : r;
             });
+        }
 
         /// <summary>
         /// Lift the pure value into the monadic space

--- a/src/Isotope80.Shared/IsotopeAsync_A.cs
+++ b/src/Isotope80.Shared/IsotopeAsync_A.cs
@@ -97,6 +97,22 @@ namespace Isotope80
             });
 
         /// <summary>
+        /// Run lhs, if it fails run rhs with the failed state (preserving Page, BrowserContext, etc.)
+        /// Unlike | which resets to the original state for retry semantics.
+        /// </summary>
+        public static IsotopeAsync<A> OnFail(IsotopeAsync<A> lhs, IsotopeAsync<A> rhs) =>
+            new IsotopeAsync<A>(async s =>
+            {
+                var l = await lhs.Invoke(s).ConfigureAwait(false);
+                if (!l.IsFaulted) return l;
+
+                var r = await rhs.Invoke(l.State.With(Error: default(Seq<Error>))).ConfigureAwait(false);
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
+            });
+
+        /// <summary>
         /// Lift the pure value into the monadic space
         /// </summary>
         public static IsotopeAsync<A> Pure(A value) =>

--- a/src/Isotope80.Shared/IsotopeAsync_Env_A.cs
+++ b/src/Isotope80.Shared/IsotopeAsync_Env_A.cs
@@ -112,6 +112,22 @@ namespace Isotope80
                                      });
 
         /// <summary>
+        /// Run lhs, if it fails run rhs with the failed state (preserving Page, BrowserContext, etc.)
+        /// Unlike | which resets to the original state for retry semantics.
+        /// </summary>
+        public static IsotopeAsync<Env, A> OnFail(IsotopeAsync<Env, A> lhs, IsotopeAsync<Env, A> rhs) =>
+            new IsotopeAsync<Env, A>(async (e, s) =>
+            {
+                var l = await lhs.Invoke(e, s).ConfigureAwait(false);
+                if (!l.IsFaulted) return l;
+
+                var r = await rhs.Invoke(e, l.State.With(Error: default(Seq<Error>))).ConfigureAwait(false);
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
+            });
+
+        /// <summary>
         /// Lift the pure value into the monadic space
         /// </summary>
         public static IsotopeAsync<Env, A> Pure(A value) =>

--- a/src/Isotope80.Shared/IsotopeAsync_Env_A.cs
+++ b/src/Isotope80.Shared/IsotopeAsync_Env_A.cs
@@ -112,20 +112,23 @@ namespace Isotope80
                                      });
 
         /// <summary>
-        /// Run lhs, if it fails run rhs with the failed state (preserving Page, BrowserContext, etc.)
+        /// Run the operation, if it fails run the handler with the failed state (preserving Page, BrowserContext, etc.)
         /// Unlike | which resets to the original state for retry semantics.
         /// </summary>
-        public static IsotopeAsync<Env, A> OnFail(IsotopeAsync<Env, A> lhs, IsotopeAsync<Env, A> rhs) =>
-            new IsotopeAsync<Env, A>(async (e, s) =>
+        public IsotopeAsync<Env, A> OnFail(IsotopeAsync<Env, A> handler)
+        {
+            var operation = this;
+            return new IsotopeAsync<Env, A>(async (e, s) =>
             {
-                var l = await lhs.Invoke(e, s).ConfigureAwait(false);
+                var l = await operation.Invoke(e, s).ConfigureAwait(false);
                 if (!l.IsFaulted) return l;
 
-                var r = await rhs.Invoke(e, l.State.With(Error: default(Seq<Error>))).ConfigureAwait(false);
+                var r = await handler.Invoke(e, l.State.With(Error: default(Seq<Error>))).ConfigureAwait(false);
                 return r.IsFaulted
-                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           ? new IsotopeState<A>(default, l.State.With(Error: l.State.Error + r.State.Error))
                            : r;
             });
+        }
 
         /// <summary>
         /// Lift the pure value into the monadic space

--- a/src/Isotope80.Shared/Isotope_A.cs
+++ b/src/Isotope80.Shared/Isotope_A.cs
@@ -79,6 +79,22 @@ namespace Isotope80
             });
 
         /// <summary>
+        /// Run lhs, if it fails run rhs with the failed state (preserving Page, BrowserContext, etc.)
+        /// Unlike | which resets to the original state for retry semantics.
+        /// </summary>
+        public static Isotope<A> OnFail(Isotope<A> lhs, Isotope<A> rhs) =>
+            new Isotope<A>(s =>
+            {
+                var l = lhs.Invoke(s);
+                if (!l.IsFaulted) return l;
+
+                var r = rhs.Invoke(l.State.With(Error: default(Seq<Error>)));
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
+            });
+
+        /// <summary>
         /// Implicit conversion from Error
         /// </summary>
         /// <returns></returns>

--- a/src/Isotope80.Shared/Isotope_A.cs
+++ b/src/Isotope80.Shared/Isotope_A.cs
@@ -79,20 +79,23 @@ namespace Isotope80
             });
 
         /// <summary>
-        /// Run lhs, if it fails run rhs with the failed state (preserving Page, BrowserContext, etc.)
+        /// Run the operation, if it fails run the handler with the failed state (preserving Page, BrowserContext, etc.)
         /// Unlike | which resets to the original state for retry semantics.
         /// </summary>
-        public static Isotope<A> OnFail(Isotope<A> lhs, Isotope<A> rhs) =>
-            new Isotope<A>(s =>
+        public Isotope<A> OnFail(Isotope<A> handler)
+        {
+            var operation = this;
+            return new Isotope<A>(s =>
             {
-                var l = lhs.Invoke(s);
+                var l = operation.Invoke(s);
                 if (!l.IsFaulted) return l;
 
-                var r = rhs.Invoke(l.State.With(Error: default(Seq<Error>)));
+                var r = handler.Invoke(l.State.With(Error: default(Seq<Error>)));
                 return r.IsFaulted
-                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           ? new IsotopeState<A>(default, l.State.With(Error: l.State.Error + r.State.Error))
                            : r;
             });
+        }
 
         /// <summary>
         /// Implicit conversion from Error

--- a/src/Isotope80.Shared/Isotope_Env_A.cs
+++ b/src/Isotope80.Shared/Isotope_Env_A.cs
@@ -95,6 +95,22 @@ namespace Isotope80
                                 });
 
         /// <summary>
+        /// Run lhs, if it fails run rhs with the failed state (preserving Page, BrowserContext, etc.)
+        /// Unlike | which resets to the original state for retry semantics.
+        /// </summary>
+        public static Isotope<Env, A> OnFail(Isotope<Env, A> lhs, Isotope<Env, A> rhs) =>
+            new Isotope<Env, A>((e, s) =>
+            {
+                var l = lhs.Invoke(e, s);
+                if (!l.IsFaulted) return l;
+
+                var r = rhs.Invoke(e, l.State.With(Error: default(Seq<Error>)));
+                return r.IsFaulted
+                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           : r;
+            });
+
+        /// <summary>
         /// Lift the pure value into the monadic space
         /// </summary>
         public static Isotope<Env, A> Pure(A value) =>

--- a/src/Isotope80.Shared/Isotope_Env_A.cs
+++ b/src/Isotope80.Shared/Isotope_Env_A.cs
@@ -95,20 +95,23 @@ namespace Isotope80
                                 });
 
         /// <summary>
-        /// Run lhs, if it fails run rhs with the failed state (preserving Page, BrowserContext, etc.)
+        /// Run the operation, if it fails run the handler with the failed state (preserving Page, BrowserContext, etc.)
         /// Unlike | which resets to the original state for retry semantics.
         /// </summary>
-        public static Isotope<Env, A> OnFail(Isotope<Env, A> lhs, Isotope<Env, A> rhs) =>
-            new Isotope<Env, A>((e, s) =>
+        public Isotope<Env, A> OnFail(Isotope<Env, A> handler)
+        {
+            var operation = this;
+            return new Isotope<Env, A>((e, s) =>
             {
-                var l = lhs.Invoke(e, s);
+                var l = operation.Invoke(e, s);
                 if (!l.IsFaulted) return l;
 
-                var r = rhs.Invoke(e, l.State.With(Error: default(Seq<Error>)));
+                var r = handler.Invoke(e, l.State.With(Error: default(Seq<Error>)));
                 return r.IsFaulted
-                           ? new IsotopeState<A>(default, s.With(Error: l.State.Error + r.State.Error))
+                           ? new IsotopeState<A>(default, l.State.With(Error: l.State.Error + r.State.Error))
                            : r;
             });
+        }
 
         /// <summary>
         /// Lift the pure value into the monadic space


### PR DESCRIPTION
Added OnFail method to all four Isotope types (Isotope<A>, Isotope<Env, A>, IsotopeAsync<A>, IsotopeAsync<Env, A>).

Unlike the | operator which passes the original state to the recovery handler (designed for retries), OnFail passes the failed state with errors cleared. This means diagnostic handlers like screenshot/page source capture see the correct tab — the one where the test actually failed — instead of the initial tab.

Added 4 tests:
- 2 sync tests verifying state propagation via initConfig/config
- 2 async Playwright tests proving OnFail reads page source from the failed tab while | reads from the original tab